### PR TITLE
Adds learn more link to pop-up for metric final/not-final states

### DIFF
--- a/extension/src/browser_action/popup.js
+++ b/extension/src/browser_action/popup.js
@@ -113,7 +113,7 @@ function buildLocalMetricsTemplate(metrics) {
         </div>
         <div class="lh-metric lh-metric--${metrics.fid.pass ? 'pass':'fail'}">
           <div class="lh-metric__innerwrap">
-            <span class="lh-metric__title">First Input Delay <span class="lh-metric-state">${metrics.fid.final ? '(final)' : '(not final)'}</span></span>
+            <span class="lh-metric__title">First Input Delay <span class="lh-metric-state">${metrics.fid.final ? '(final)' : '(not final - waiting for input)'}</span></span>
             <div class="lh-metric__value">${metrics.fid.value.toFixed(2)}&nbsp;ms</div>
           </div>
         </div>
@@ -125,6 +125,7 @@ function buildLocalMetricsTemplate(metrics) {
         </div>
       </div>
     </div>
+    <div class="lh-footer"><a href="https://github.com/GoogleChrome/web-vitals#api" target="_blank">Learn more</a> about when these values are final</div>
   </div>`;
 }
 

--- a/extension/src/browser_action/viewer.css
+++ b/extension/src/browser_action/viewer.css
@@ -351,6 +351,12 @@
   color: var(--color-informative);
 }
 
+.lh-footer {
+  margin-top: 20px;
+  font-size: 12px;
+  color: var(--color-gray-500);
+}
+
 .lh-audit__description, .lh-audit__stackpack {
   --inner-audit-padding-right: var(--stackpack-padding-horizontal);
   padding-left: var(--audit-description-padding-left);


### PR DESCRIPTION
This change makes the reason for FID not being final more explicit and adds a link to learn more about what final/not-final mean for #17 

<img width="560" alt="Screen Shot 2020-04-23 at 3 50 53 PM" src="https://user-images.githubusercontent.com/110953/80157180-709c0980-857a-11ea-8535-e8f4ccff0137.png">

cc @philipwalton @robdodson 

If we want to add explanations for the other metrics not being final (that are short), happy to look at that as part of this PR or another provided we have suggestions... :)

e.g "waiting for visibilitychange" or something perhaps.
