### PR TITLE
Shows a message for LCP only tab is loaded in background

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -57,6 +57,14 @@ function getWebVitals(tabId) {
 
 // User has navigated to a new URL in a tab
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  const tabIdKey = tabId.toString();
+
+  if (tab.active) {
+    chrome.storage.local.set({[tabIdKey]: false});
+  } else {
+    chrome.storage.local.set({[tabIdKey]: true}); // tab was loaded in background
+  }
+
   if (
     changeInfo.status == 'complete' &&
     tab.url.startsWith('http') &&

--- a/src/browser_action/viewer.css
+++ b/src/browser_action/viewer.css
@@ -607,6 +607,12 @@
   font-weight: 500;
 }
 
+.lh-metric__subtitle {
+  display: block;
+  font-weight: 500;
+  color: var(--color-gray-500);
+}
+
 .lh-metrics__disclaimer {
   color: var(--color-gray-600);
   margin: var(--section-padding-vertical) 0;


### PR DESCRIPTION
Fixes #7.

Instead of relying on Page Visibility, this just checks for tabs that are updated but not active at the same time (and stores a boolean that `popup.js` checks for before displaying a message).

If you think the message should live within a toggle or `<details>`, I can update this!

![Screen Shot 2020-04-30 at 6 15 10 PM](https://user-images.githubusercontent.com/12476932/80764369-91320980-8b0e-11ea-81a1-d7d224b9b6d3.png)

## Gif

![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/12476932/80764297-5fb93e00-8b0e-11ea-851e-aff636501000.gif)

