### PR TITLE
[core] Updates close property of overlay

### DIFF
--- a/src/browser_action/viewer.css
+++ b/src/browser_action/viewer.css
@@ -1735,6 +1735,7 @@
   border-image: initial;
   display: block; 
   margin: 7px 9px 0px 0px;
+  cursor: pointer;
 }
 
 .lh-footer .lh-generated {

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -83,9 +83,15 @@
     // Check for preferences set in options
     chrome.storage.sync.get({
       enableOverlay: false,
+      closedOverlayTabs: {}
     }, ({
-      enableOverlay,
+      enableOverlay, closedOverlayTabs
     }) => {
+      // check if overlay was previously closed on this tab
+      if (closedOverlayTabs[tabId]) {
+        return;
+      }
+
       if (enableOverlay === true) {
         // Overlay
         const overlayElement = document.getElementById('web-vitals-extension');
@@ -107,27 +113,18 @@
           overlayClose.className = 'lh-overlay-close';
 
           document.body.appendChild(overlayClose);
+        } else {
+          overlayClose.addEventListener('click', () => {
+            overlayElement.remove();
+            overlayClose.remove();
+
+            // add tab id to hash of tabs where the overlay was closed
+            chrome.storage.sync.set({
+              closedOverlayTabs: { ...closedOverlayTabs, [tabId]: true },
+            });
+          });
         }
-
-        overlayClose.addEventListener('click', () => {
-          closeOverlay(overlayElement, overlayClose);
-        });
       }
-    });
-  }
-
-  /**
- * Closes the overlay and disables it from the options menu
- * @param {Element} overlayElement
- * @param {Element} overlayCloseElement
- */
-
-  function closeOverlay(overlayElement, overlayCloseElement) {
-    overlayElement.remove();
-    overlayCloseElement.remove();
-
-    chrome.storage.sync.set({
-      enableOverlay: false,
     });
   }
 

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -86,7 +86,7 @@
     }, ({
       enableOverlay,
     }) => {
-      if (enableOverlay === true && overlayClosedForSession == false) {
+      if (enableOverlay === true) {
         // Overlay
         const overlayElement = document.getElementById('web-vitals-extension');
         if (overlayElement === null) {
@@ -105,20 +105,29 @@
           overlayClose.innerText = 'Close';
           overlayClose.id = 'web-vitals-close';
           overlayClose.className = 'lh-overlay-close';
-          overlayClose.addEventListener('click', () => {
-            overlayElement.remove();
-            overlayClose.remove();
-            overlayClosedForSession = true;
-          });
+
           document.body.appendChild(overlayClose);
-        } else {
-          overlayClose.addEventListener('click', () => {
-            overlayElement.remove();
-            overlayClose.remove();
-            overlayClosedForSession = true;
-          });
         }
+
+        overlayClose.addEventListener('click', () => {
+          closeOverlay(overlayElement, overlayClose);
+        });
       }
+    });
+  }
+
+  /**
+ * Return a short (host) and full URL for the measured page
+ * @param {Element} overlayElement
+ * @param {Element} overlayCloseElement
+ */
+
+  function closeOverlay(overlayElement, overlayCloseElement) {
+    overlayElement.remove();
+    overlayCloseElement.remove();
+
+    chrome.storage.sync.set({
+      enableOverlay: false,
     });
   }
 

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -117,7 +117,7 @@
   }
 
   /**
- * Return a short (host) and full URL for the measured page
+ * Closes the overlay and disables it from the options menu
  * @param {Element} overlayElement
  * @param {Element} overlayCloseElement
  */

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -7,6 +7,7 @@ const optionsStatus = document.getElementById('status');
  */
 function saveOptions() {
   chrome.storage.sync.set({
+    closedOverlayTabs: {}, // resets closed tab ids
     enableOverlay: optionsOverlayNode.checked,
   }, () => {
     // Update status to let user know options were saved.


### PR DESCRIPTION
Fixes #38 

"Close" disables the overlay for the current tab completely. Reloading the page, navigating to a different URL and switching back and forth does not re-surface the overlay (as it previously did). 

![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/12476932/81121758-7fc97280-8efd-11ea-8835-13bd28205ca1.gif)

Only going to "Options" and re-enabling the setting will show the overlay on the current tab again.


