### PR TITLE
Use HTML <template> for rendering local metrics

### DIFF
--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -7,11 +7,11 @@
     .lh-audit-group--metrics, .lh-metrics-final {
       padding: 3px 10px 0px 10px;
     }
-    
+
     .lh-metric-state {
       color: #cccccc;
     }
-    
+
     .lh-topbar {
       position: sticky;
       top: 0;
@@ -25,7 +25,7 @@
       padding: var(--topbar-padding);
       font-size: 12px;
     }
-    
+
     .lh-topbar a, .lh-topbar a:active {
       color: var(--color-gray-900);
       text-decoration: none;
@@ -41,7 +41,55 @@
         <div class="lh-category-wrapper-">
           <div class="lh-category-custom" id="local-metrics">
             Metrics data unavailable.
+
             <!-- Placeholder content -->
+            <template id="local-metrics-template">
+              <div class="lh-topbar">
+                <a id="local-test-url" href="" class="lh-topbar__url" target="_blank" rel="noopener" title=""></a>&nbsp;-&nbsp;<span id="local-test-time"></span>
+              </div>
+                <div class="lh-audit-group lh-audit-group--metrics">
+                <div class="lh-audit-group__header"><span class="lh-audit-group__title">Metrics</span></div>
+                <div class="lh-columns">
+                  <div class="lh-column">
+                    <div id="metric-lcp" class="lh-metric">
+                      <div class="lh-metric__innerwrap">
+                        <div>
+                          <span class="lh-metric__title">
+                            Largest Contentful Paint
+                            <span class="lh-metric-state"></span>
+                          </span>
+                          <span class="lh-metric__subtitle"></span>
+                        </div>
+                        <div class="lh-metric__value"></div>
+                      </div>
+                    </div>
+                    <div id="metric-fid" class="lh-metric">
+                      <div class="lh-metric__innerwrap">
+                        <span class="lh-metric__title">
+                          First Input Delay
+                          <span class="lh-metric-state"></span>
+                        </span>
+                        <div class="lh-metric__value"></div>
+                      </div>
+                    </div>
+                    <div id="metric-cls" class="lh-metric">
+                      <div class="lh-metric__innerwrap">
+                        <span class="lh-metric__title">
+                          Cumulative Layout Shift
+                          <span class="lh-metric-state"></span>
+                        </span>
+                        <div class="lh-metric__value"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="lh-footer lh-warning">
+                Mobile performance may be significantly slower.
+                <a href="https://web.dev/load-fast-enough-for-pwa/" target="_blank">Learn more</a>
+              </div>
+            </template>
           </div>
         </div>
         <!-- End Lighthouse report -->

--- a/src/browser_action/popup.js
+++ b/src/browser_action/popup.js
@@ -79,7 +79,7 @@ function createPSITemplate(result) {
     const overall_category = experience.overall_category;
     const fcp = metrics.FIRST_CONTENTFUL_PAINT_MS;
     const fid = metrics.FIRST_INPUT_DELAY_MS;
-  
+
     const fcp_template = buildDistributionTemplate(fcp, 'First Contentful Paint (FCP)');
     const fid_template = buildDistributionTemplate(fid, 'First Input Delay (FID)');
     const link_template = buildPSILink();
@@ -93,67 +93,56 @@ function createPSITemplate(result) {
 
 /**
  *
- * Construct a WebVitals.js metrics template for display at the
- * top of the pop-up. Consumes a custom metrics object provided
- * by vitals.js.
- * @param {Object} metrics
- * @returns
- */
-function buildLocalMetricsTemplate(metrics, tabLoadedInBackground) {
-  return `
-  <div class="lh-topbar">
-    <a href="${metrics.location.url}" class="lh-topbar__url" target="_blank" rel="noopener" title="${metrics.location.url}">
-  ${metrics.location.shortURL}</a>&nbsp;- ${metrics.timestamp}
-  </div>
-    <div class="lh-audit-group lh-audit-group--metrics">
-    <div class="lh-audit-group__header"><span class="lh-audit-group__title">Metrics</span></div>
-    <div class="lh-columns">
-      <div class="lh-column">
-        <div class="lh-metric lh-metric--${metrics.lcp.pass ? 'pass':'fail'}">
-          <div class="lh-metric__innerwrap">
-            <div>
-              <span class="lh-metric__title">Largest Contentful Paint <span class="lh-metric-state">${metrics.lcp.final ? '' : '(might change)'}</span></span>
-              ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
-            </div>
-            <div class="lh-metric__value">${(metrics.lcp.value/1000).toFixed(2)}&nbsp;s</div>
-          </div>
-        </div>
-        <div class="lh-metric lh-metric--${metrics.fid.pass ? 'pass':'fail'}">
-          <div class="lh-metric__innerwrap">
-            <span class="lh-metric__title">First Input Delay <span class="lh-metric-state">${metrics.fid.final ? '' : '(waiting for input)'}</span></span>
-            <div class="lh-metric__value">${metrics.fid.final ? `${metrics.fid.value.toFixed(2)}&nbsp;ms` : ''}</div>
-          </div>
-        </div>
-        <div class="lh-metric lh-metric--${metrics.cls.pass ? 'pass':'fail'}">
-          <div class="lh-metric__innerwrap">
-            <span class="lh-metric__title">Cumulative Layout Shift <span class="lh-metric-state">${metrics.cls.final ? '' : '(might change)'}</span></span>
-            <div class="lh-metric__value">${metrics.cls.value.toFixed(3)}&nbsp;</div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="lh-metrics-final lh-metrics__disclaimer" hidden>
-    <div><span>${metrics.location.url} - ${metrics.timestamp}</span></div>
-  </div>
-
-    <div class="lh-footer lh-warning">
-      Mobile performance may be significantly slower. 
-      <a href="https://web.dev/load-fast-enough-for-pwa/" target="_blank">Learn more</a>
-    </div>
-  </div>
-  `;
-}
-
-/**
- *
  * Render a WebVitals.js metrics table in the pop-up window
  * @param {Object} metrics
  * @returns
  */
 function renderLocalMetricsTemplate(metrics, tabLoadedInBackground) {
-  const el = document.getElementById('local-metrics');
-  el.innerHTML = buildLocalMetricsTemplate(metrics, tabLoadedInBackground);
+  const localMetrics = document.getElementById('local-metrics');
+  let template = document.getElementById('local-metrics-template');
+  if (template) {
+    template = template.content.cloneNode(true);
+  } else {
+    // If the template doesn't exist anymore, reuse what's already been rendered.
+    template = localMetrics;
+  }
+
+  // Set the URL and timestamp info for debugging.
+  const testUrl = template.getElementById('local-test-url');
+  testUrl.setAttribute('href', metrics.location.url);
+  testUrl.setAttribute('title', metrics.location.url);
+  testUrl.innerText = metrics.location.shortURL;
+  const testTime = template.getElementById('local-test-time');
+  testTime.innerText = metrics.timestamp;
+
+  // Set metric info.
+  const lcp = template.getElementById('metric-lcp');
+  lcp.classList.add(`lh-metric--${metrics.lcp.pass ? 'pass':'fail'}`);
+  const lcpState = lcp.querySelector('.lh-metric-state');
+  lcpState.innerText = metrics.lcp.final ? '' : '(might change)';
+  const lcpSubtitle = lcp.querySelector('.lh-metric__subtitle');
+  lcpSubtitle.innerText = tabLoadedInBackground ? 'Value inflated as tab was loaded in background' : '';
+  const lcpValue = lcp.querySelector('.lh-metric__value');
+  lcpValue.innerText = `${(metrics.lcp.value/1000).toFixed(2)} s`;
+
+  const fid = template.getElementById('metric-fid');
+  fid.classList.add(`lh-metric--${metrics.fid.pass ? 'pass':'fail'}`);
+  const fidState = fid.querySelector('.lh-metric-state');
+  fidState.innerText = metrics.fid.final ? '' : '(waiting for input)';
+  const fidValue = fid.querySelector('.lh-metric__value');
+  fidValue.innerText = `${metrics.fid.final ? `${metrics.fid.value.toFixed(2)} ms` : ''}`;
+
+  const cls = template.getElementById('metric-cls');
+  cls.classList.add(`lh-metric--${metrics.cls.pass ? 'pass':'fail'}`);
+  const clsState = cls.querySelector('.lh-metric-state');
+  clsState.innerText = metrics.cls.final ? '' : '(might change)';
+  const clsValue = cls.querySelector('.lh-metric__value');
+  clsValue.innerText = metrics.cls.value.toFixed(3);
+
+  if (template.id != 'local-metrics') {
+    localMetrics.innerHTML = '';
+    localMetrics.appendChild(template);
+  }
 }
 
 function buildDistributionTemplate(metric, label) {
@@ -164,13 +153,13 @@ function buildDistributionTemplate(metric, label) {
           <span class="metric-description">${label}</span>
           <div class="metric-value lh-metric__value">${formatDisplayValue(label, metric.percentile)}</div></div>
         <div class="metric-chart">
-          <div class="bar fast" style="flex-grow: 
+          <div class="bar fast" style="flex-grow:
           ${Math.floor(metric.distributions[0].proportion * 100)};">
           ${Math.floor(metric.distributions[0].proportion * 100)}%</div>
-          <div class="bar average" style="flex-grow: 
+          <div class="bar average" style="flex-grow:
           ${Math.floor(metric.distributions[1].proportion * 100)};">
           ${Math.floor(metric.distributions[1].proportion * 100)}%</div>
-          <div class="bar slow" style="flex-grow: 
+          <div class="bar slow" style="flex-grow:
           ${Math.floor(metric.distributions[2].proportion * 100)};">
           ${Math.floor(metric.distributions[2].proportion * 100)}%</div>
         </div></div>
@@ -212,7 +201,7 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
   if (thisTab.url) {
     const key = hashCode(thisTab.url);
     const loadedInBackgroundKey = thisTab.id.toString()
-    
+
     let tabLoadedInBackground = false;
 
     chrome.storage.local.get(loadedInBackgroundKey, (result) => {


### PR DESCRIPTION
This is a small refactor that uses the semantic `<template>` element to define the markup structure of the local metric results.

This approach moves the markup into the HTML file and the dynamic content is updated using DOM APIs. Decoupling the HTML from JS makes it more maintainable. `innerHTML` is also known to be insecure, but I'm not sure of the severity in an extension context.

Other parts of the UI are generated in JS and I'd be happy to revisit those using this approach if this PR gets merged.