### PR TITLE
Improve style scoping 

### DIFF
--- a/src/browser_action/core.css
+++ b/src/browser_action/core.css
@@ -1,16 +1,16 @@
-html {
+.web-vitals-chrome-extension-popup {
     width: 450px;
     height: 180px;
     text-align: left;
     font: 400 14px/20px Roboto,sans-serif
 }
 
-h1 {
+.web-vitals-chrome-extension-popup h1 {
     margin-left: 14px;
     font-size: 1.5em;
 }
 
-.main-action {
+.web-vitals-chrome-extension-popup .main-action {
     padding: 4rem 0 0;
     background: #007bff;
     line-height: 4rem;
@@ -18,17 +18,17 @@ h1 {
     margin-bottom: 3rem;
 }
 
-.main-action div.url-and-analyze .url {
+.web-vitals-chrome-extension-popup .main-action div.url-and-analyze .url {
     width: 600px;
     height: auto;
     padding-left: 8px;
 }
 
-.dark-mode-theme .main-action div.url-and-analyze .url {
+.web-vitals-chrome-extension-popup .dark-mode-theme .main-action div.url-and-analyze .url {
     background: #e4e4e4;
 }
 
-.main-action div.analyze-cell {
+.web-vitals-chrome-extension-popup .main-action div.analyze-cell {
     border: none;
     color: #fff;
     margin-left: 8px;
@@ -37,51 +37,51 @@ h1 {
     line-height: 32px;
 }
 
-.main-action .main-submit {
+.web-vitals-chrome-extension-popup .main-action .main-submit {
     background-color: #3367d6;
     box-shadow: none;
     padding: 8px 16px;
     cursor: pointer;
 }
 
-.main-action .form-check-input {
+.web-vitals-chrome-extension-popup .main-action .form-check-input {
    margin-top: 1.2rem;
     margin-left: -2rem;
 }
 
-.main-action .form-check-label {
+.web-vitals-chrome-extension-popup .main-action .form-check-label {
     color: #fff;
     font-size: 1.6rem;
 }
 
-.report-summary {
+.web-vitals-chrome-extension-popup .report-summary {
     flex-wrap: nowrap;
     align-items: center;
     word-break: break-word;
     font-size: 1.5rem;
 }
 
-.report-summary .gauge-scale {
+.web-vitals-chrome-extension-popup .report-summary .gauge-scale {
     margin: 8px 0;
 }
 
-.report-summary p {
+.web-vitals-chrome-extension-popup .report-summary p {
     margin: 8px 0;
 }
 
-.report-summary .range.fast::before {
+.web-vitals-chrome-extension-popup .report-summary .range.fast::before {
     background-color: #178239;
 }
 
-.report-summary .range.average::before {
+.web-vitals-chrome-extension-popup .report-summary .range.average::before {
     background-color: #e67700;
 }
 
-.report-summary .range.slow::before {
+.web-vitals-chrome-extension-popup .report-summary .range.slow::before {
     background-color: #c7221f;
 }
 
-.report-summary .gauge-scale .range::before {
+.web-vitals-chrome-extension-popup .report-summary .gauge-scale .range::before {
     content: '';
     width: 16px;
     height: 8px;
@@ -90,22 +90,22 @@ h1 {
     margin: 1px 8px;
 }
 
-.bottom-border {
+.web-vitals-chrome-extension-popup .bottom-border {
     border-bottom: solid 1px #e0e0e0;
 }
 
-.dark-mode-theme .bottom-border {
+.web-vitals-chrome-extension-popup .dark-mode-theme .bottom-border {
     border-bottom: 1px solid #464646;
 }
 
-.summary-description .audited-url {
+.web-vitals-chrome-extension-popup .summary-description .audited-url {
     font-size: 2rem;
     font-weight: 400;
     width: 60px;
     color: inherit;
 }
 
-.loading-spinner .text-center {
+.web-vitals-chrome-extension-popup .loading-spinner .text-center {
     color: red;
     animation: changecolor 3s linear infinite;
     -webkit-animation: changecolor 3s linear infinite;
@@ -142,7 +142,7 @@ h1 {
 }
 
 /* tabs */
-.result-tabs {
+.web-vitals-chrome-extension-popup .result-tabs {
     color: #fff;
     font-weight: 500;
     height: 50px;
@@ -150,21 +150,21 @@ h1 {
     right: 0;
 }
 
-.result-tabs .goog-tab-selected .icon, .result-tabs .goog-tab-selected.goog-tab-hover .icon, .result-tabs .goog-tab-selected .tab-title, .result-tabs .goog-tab-selected.goog-tab-hover .tab-title {
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected .icon, .result-tabs .goog-tab-selected.goog-tab-hover .icon, .result-tabs .goog-tab-selected .tab-title, .result-tabs .goog-tab-selected.goog-tab-hover .tab-title {
     opacity: 1;
 }
 
-.result-tabs .goog-tab .icon, .result-tabs .goog-tab .tab-title {
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab .icon, .result-tabs .goog-tab .tab-title {
     opacity: .8;
     transition: opacity .1s ease;
 }
 
-.result-tabs .tab-title {
+.web-vitals-chrome-extension-popup .result-tabs .tab-title {
     display: inline;
     padding: 0 8px;
 }
 
-.result-tabs .tab-bar-wrapper {
+.web-vitals-chrome-extension-popup .result-tabs .tab-bar-wrapper {
     background: #007bff;
     box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 1px 0 0 rgba(0, 0, 0, 0.01);
     height: 50px;
@@ -173,16 +173,16 @@ h1 {
     text-transform: uppercase;
 }
 
-.dark-mode-theme .result-tabs .tab-bar-wrapper,.dark-mode-theme .main-action {
+.web-vitals-chrome-extension-popup .dark-mode-theme .result-tabs .tab-bar-wrapper,.dark-mode-theme .main-action {
     background: #0c3b6d;
 }
 
-.result-tabs .goog-tab-selected {
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected {
     border-bottom: solid 2px #fff;
     z-index: 2;
 }
 
-.result-tabs .goog-tab {
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab {
     border-radius: 2px 2px 0 0;
     cursor: pointer;
     display: inline-block;
@@ -204,11 +204,11 @@ h1 {
 /* tabs */
 
 
-.tooltip-boundary {
+.web-vitals-chrome-extension-popup .tooltip-boundary {
     position: relative;
 }
 
-.tooltip-inner {
+.web-vitals-chrome-extension-popup .tooltip-inner {
     font-size: 1.5rem;
     text-align: left;
     padding: 1rem;
@@ -216,35 +216,35 @@ h1 {
     color: #111;
 }
 
-.tooltip > .arrow:before {
+.web-vitals-chrome-extension-popup .tooltip > .arrow:before {
     border-top-color: #ddd;
 }
 
-.field-data {
+.web-vitals-chrome-extension-popup .field-data {
     font-weight: normal;
     /* padding-top: 24px; */
 }
 
-.field-data .metrics {
+.web-vitals-chrome-extension-popup .field-data .metrics {
     display: flex;
     flex-wrap: nowrap;
     flex: 1;
     width: 100%;
 }
 
-.field-data .metric-wrapper {
+.web-vitals-chrome-extension-popup .field-data .metric-wrapper {
     font-size: 14px;
     flex: 1;
     padding: 1rem;
 }
 
-.field-data .metric-wrapper .metric-chart {
+.web-vitals-chrome-extension-popup .field-data .metric-wrapper .metric-chart {
     display: flex;
     margin-top: 16px;
     margin-bottom: 24px
 }
 
-.field-data .metric-wrapper .metric-chart .bar {
+.web-vitals-chrome-extension-popup .field-data .metric-wrapper .metric-chart .bar {
     display: inline-block;
     line-height: 24px;
     text-align: center;
@@ -252,22 +252,22 @@ h1 {
     margin-left: 2px
 }
 
-.field-data .metric-wrapper .metric-chart .fast {
+.web-vitals-chrome-extension-popup .field-data .metric-wrapper .metric-chart .fast {
     background: #178239;
     border-radius: 4px 0 0 4px
 }
 
-.field-data .metric-wrapper .metric-chart .average {
+.web-vitals-chrome-extension-popup .field-data .metric-wrapper .metric-chart .average {
     background: #e67700;
     color: #000
 }
 
-.field-data .metric-wrapper .metric-chart .slow {
+.web-vitals-chrome-extension-popup .field-data .metric-wrapper .metric-chart .slow {
     background: #c7221f;
     border-radius: 0 4px 4px 0
 }
 
-.field-data-title::before {
+.web-vitals-chrome-extension-popup .field-data-title::before {
     content: '';
     width: 32px;
     height: 32px;
@@ -280,17 +280,17 @@ h1 {
 }
 
 
-.metric-wrapper:first-of-type, .lh-column:first-of-type {
+.web-vitals-chrome-extension-popup .metric-wrapper:first-of-type, .lh-column:first-of-type {
     margin-left: 0;
     margin-right: 12px
 }
 
-.metric-wrapper, .lh-column {
+.web-vitals-chrome-extension-popup .metric-wrapper, .lh-column {
     margin-left: 12px;
     margin-right: 0
 }
 
-.field-data .field-metric {
+.web-vitals-chrome-extension-popup .field-data .field-metric {
     display: flex;
     white-space: nowrap;
     padding: 8px;
@@ -298,7 +298,7 @@ h1 {
     border-bottom: solid 1px #e0e0e0
 }
 
-.field-data .field-metric .metric-value::after {
+.web-vitals-chrome-extension-popup .field-data .field-metric .metric-value::after {
     content: '';
     width: 16px;
     height: 16px;
@@ -307,94 +307,94 @@ h1 {
     margin-left: 8px
 }
 
-.field-data .field-metric.fast .metric-value {
+.web-vitals-chrome-extension-popup .field-data .field-metric.fast .metric-value {
     color: #178239
 }
 
-.field-data .field-metric.fast .metric-value::after {
+.web-vitals-chrome-extension-popup .field-data .field-metric.fast .metric-value::after {
     background: url(//www.gstatic.com/pagespeed/insights/67/img/ic_check_circle.svg) no-repeat;
     background-size: 16px 16px
 }
 
-.field-data .field-metric.average .metric-value {
+.web-vitals-chrome-extension-popup .field-data .field-metric.average .metric-value {
     color: #e67700
 }
 
-.field-data .field-metric.average .metric-value::after {
+.web-vitals-chrome-extension-popup .field-data .field-metric.average .metric-value::after {
     background: url(//www.gstatic.com/pagespeed/insights/67/img/ic_info.svg) no-repeat;
     background-size: 16px 16px
 }
 
-.field-data .field-metric.slow .metric-value {
+.web-vitals-chrome-extension-popup .field-data .field-metric.slow .metric-value {
     color: #c7221f
 }
 
-.field-data .field-metric.slow .metric-value::after {
+.web-vitals-chrome-extension-popup .field-data .field-metric.slow .metric-value::after {
     background: url(//www.gstatic.com/pagespeed/insights/67/img/ic_warning.svg) no-repeat;
     background-size: 16px 16px
 }
 
 
 
-.field-data-description, .lh-audit-group__description {
+.web-vitals-chrome-extension-popup .field-data-description, .lh-audit-group__description {
     font-size: 1.5rem;
     padding: 8px;
     font-weight: 600;
     background: #eee;
 }
 
-.lh-audit-group__description, .field-data-description, .lh-audit-group__subheader--title {
+.web-vitals-chrome-extension-popup .lh-audit-group__description, .field-data-description, .lh-audit-group__subheader--title {
     background: #eee;
     border-bottom: 1px solid #bdbdbd;
     border-right: 1px solid #bdbdbd;
 }
 
 
-.dark-mode-theme .lh-audit-group__description, .dark-mode-theme .field-data-description, .dark-mode-theme .lh-audit-group__subheader--title {
+.web-vitals-chrome-extension-popup .dark-mode-theme .lh-audit-group__description, .dark-mode-theme .field-data-description, .dark-mode-theme .lh-audit-group__subheader--title {
     background: #464040;
     border-bottom: 1px solid #5f5f5f;
     border-right: 1px solid #353535;
 }
 
-.field-data-description.fast b {
+.web-vitals-chrome-extension-popup .field-data-description.fast b {
     color: #178239
 }
 
-.field-data-description.average b {
+.web-vitals-chrome-extension-popup .field-data-description.average b {
     color: #e67700
 }
 
-.field-data-description.slow b {
+.web-vitals-chrome-extension-popup .field-data-description.slow b {
     color: #c7221f
 }
 
-html[dir=rtl] .result-container {
+.web-vitals-chrome-extension-popup html[dir=rtl] .result-container {
     padding: 0 32px 0 0
 }
 
-.origin-field-data {
+.web-vitals-chrome-extension-popup .origin-field-data {
     padding-top: 24px
 }
 
-.screenshot-container {
+.web-vitals-chrome-extension-popup .screenshot-container {
     padding: 24px 24px 0 24px;
     width: 18vw;
     max-width: 328px;
     min-width: 168px
 }
 
-.screenshot-container img {
+.web-vitals-chrome-extension-popup .screenshot-container img {
     border: 1px solid #e0e0e0;
     border-radius: 4px;
     width: 100%
 }
 
-.finalScreenshot img {
+.web-vitals-chrome-extension-popup .finalScreenshot img {
     max-width: 100%;
     max-height: 30rem;
 }
 
-.url-length {
+.web-vitals-chrome-extension-popup .url-length {
     word-break: break-word;
     max-width: 500px;
     white-space: nowrap;
@@ -403,17 +403,17 @@ html[dir=rtl] .result-container {
 }
 
 
-#bootup-time-chart .pass {
+.web-vitals-chrome-extension-popup #bootup-time-chart .pass {
     color: #85868a;
     font-weight: 600;
 }
 
-#bootup-time-chart .fail {
+.web-vitals-chrome-extension-popup #bootup-time-chart .fail {
     color: #c7221f;
     font-weight: 600;
 }
 
-#bootup-time-chart .average {
+.web-vitals-chrome-extension-popup #bootup-time-chart .average {
     color: #e67700;
     font-weight: 600;
 }

--- a/src/browser_action/core.css
+++ b/src/browser_action/core.css
@@ -150,11 +150,15 @@
     right: 0;
 }
 
-.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected .icon, .result-tabs .goog-tab-selected.goog-tab-hover .icon, .result-tabs .goog-tab-selected .tab-title, .result-tabs .goog-tab-selected.goog-tab-hover .tab-title {
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected .icon, 
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected.goog-tab-hover .icon, 
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected .tab-title, 
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab-selected.goog-tab-hover .tab-title {
     opacity: 1;
 }
 
-.web-vitals-chrome-extension-popup .result-tabs .goog-tab .icon, .result-tabs .goog-tab .tab-title {
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab .icon, 
+.web-vitals-chrome-extension-popup .result-tabs .goog-tab .tab-title {
     opacity: .8;
     transition: opacity .1s ease;
 }
@@ -173,7 +177,8 @@
     text-transform: uppercase;
 }
 
-.web-vitals-chrome-extension-popup .dark-mode-theme .result-tabs .tab-bar-wrapper,.dark-mode-theme .main-action {
+.web-vitals-chrome-extension-popup .dark-mode-theme .result-tabs .tab-bar-wrapper,
+.web-vitals-chrome-extension-popup .dark-mode-theme .main-action {
     background: #0c3b6d;
 }
 
@@ -280,12 +285,14 @@
 }
 
 
-.web-vitals-chrome-extension-popup .metric-wrapper:first-of-type, .lh-column:first-of-type {
+.web-vitals-chrome-extension-popup .metric-wrapper:first-of-type, 
+.web-vitals-chrome-extension-popup .lh-column:first-of-type {
     margin-left: 0;
     margin-right: 12px
 }
 
-.web-vitals-chrome-extension-popup .metric-wrapper, .lh-column {
+.web-vitals-chrome-extension-popup .metric-wrapper, 
+.web-vitals-chrome-extension-popup .lh-column {
     margin-left: 12px;
     margin-right: 0
 }
@@ -350,7 +357,9 @@
 }
 
 
-.web-vitals-chrome-extension-popup .dark-mode-theme .lh-audit-group__description, .dark-mode-theme .field-data-description, .dark-mode-theme .lh-audit-group__subheader--title {
+.web-vitals-chrome-extension-popup .dark-mode-theme .lh-audit-group__description, 
+.web-vitals-chrome-extension-popup .dark-mode-theme .field-data-description, 
+.web-vitals-chrome-extension-popup .dark-mode-theme .lh-audit-group__subheader--title {
     background: #464040;
     border-bottom: 1px solid #5f5f5f;
     border-right: 1px solid #353535;

--- a/src/browser_action/core.css
+++ b/src/browser_action/core.css
@@ -343,14 +343,17 @@
 
 
 
-.web-vitals-chrome-extension-popup .field-data-description, .lh-audit-group__description {
+.web-vitals-chrome-extension-popup .field-data-description, 
+.web-vitals-chrome-extension-popup .lh-audit-group__description {
     font-size: 1.5rem;
     padding: 8px;
     font-weight: 600;
     background: #eee;
 }
 
-.web-vitals-chrome-extension-popup .lh-audit-group__description, .field-data-description, .lh-audit-group__subheader--title {
+.web-vitals-chrome-extension-popup .lh-audit-group__description, 
+.web-vitals-chrome-extension-popup .field-data-description, 
+.web-vitals-chrome-extension-popup .lh-audit-group__subheader--title {
     background: #eee;
     border-bottom: 1px solid #bdbdbd;
     border-right: 1px solid #bdbdbd;

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="web-vitals-chrome-extension">
+<html class="web-vitals-chrome-extension web-vitals-chrome-extension-popup">
 <head>
   <link rel="stylesheet" type="text/css" href="core.css">
   <link rel="stylesheet" type="text/css" href="viewer.css">

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="web-vitals-chrome-extension">
 <head>
   <link rel="stylesheet" type="text/css" href="core.css">
   <link rel="stylesheet" type="text/css" href="viewer.css">

--- a/src/browser_action/viewer.css
+++ b/src/browser_action/viewer.css
@@ -33,13 +33,13 @@
 */
 
 /* Reset all of the CSS properties for the container */
-.lh-unset,
-.lh-unset * {
+.web-vitals-chrome-extension .lh-unset,
+.web-vitals-chrome-extension .lh-unset * {
   all: unset;
   box-sizing: border-box;
 }
 
-.lh-vars {
+.web-vitals-chrome-extension .lh-vars {
   /* Palette using Material Design Colors
    * https://www.materialui.co/colors */
   --color-amber-50: #FFF8E1;
@@ -172,7 +172,7 @@
 }
 
 @media not print {
-  .lh-vars.dark {
+  .web-vitals-chrome-extension .lh-vars.dark {
     /* Pallete */
     --color-gray-200: var(--color-gray-800);
     --color-gray-400: var(--color-gray-600);
@@ -205,7 +205,7 @@
 }
 
 @media only screen and (max-width: 480px) {
-  .lh-vars {
+  .web-vitals-chrome-extension .lh-vars {
     --audit-group-margin-bottom: 20px;
     --category-padding: 24px;
     --env-name-min-width: 120px;
@@ -232,12 +232,12 @@
   }
 
   /* Not enough space to adequately show the relative savings bars. */
-  .lh-sparkline {
+  .web-vitals-chrome-extension .lh-sparkline {
     display: none;
   }
 }
 
-.lh-vars.lh-devtools {
+.web-vitals-chrome-extension .lh-vars.lh-devtools {
   --audit-explanation-line-height: 14px;
   --audit-group-margin-bottom: 20px;
   --audit-group-padding-vertical: 12px;
@@ -269,23 +269,23 @@
   --section-padding-vertical: 8px;
 }
 
-.lh-devtools.lh-root {
+.web-vitals-chrome-extension .lh-devtools.lh-root {
   height: 100%;
 }
-.lh-devtools.lh-root img {
+.web-vitals-chrome-extension .lh-devtools.lh-root img {
   /* Override devtools default 'min-width: 0' so svg without size in a flexbox isn't collapsed. */
   min-width: auto;
 }
-.lh-devtools .lh-container {
+.web-vitals-chrome-extension .lh-devtools .lh-container {
   overflow-y: scroll;
   height: calc(100% - var(--topbar-height));
 }
 @media print {
-  .lh-devtools .lh-container {
+  .web-vitals-chrome-extension .lh-devtools .lh-container {
     overflow: unset;
   }
 }
-.lh-devtools .lh-sticky-header {
+.web-vitals-chrome-extension .lh-devtools .lh-sticky-header {
   /* This is normally the height of the topbar, but we want it to stick to the top of our scroll container .lh-container` */
   top: 0;
 }
@@ -295,12 +295,12 @@
   100% { opacity: 0.6;}
 }
 
-.lh-root *, .lh-root *::before, .lh-root *::after {
+.web-vitals-chrome-extension .lh-root *, .lh-root *::before, .lh-root *::after {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
 }
 
-.lh-root {
+.web-vitals-chrome-extension .lh-root {
   font-family: var(--report-font-family);
   font-size: var(--report-font-size);
   margin: 0;
@@ -310,23 +310,23 @@
   color: var(--report-text-color);
 }
 
-.lh-root :focus {
+.web-vitals-chrome-extension .lh-root :focus {
     outline: -webkit-focus-ring-color auto 3px;
 }
-.lh-root summary:focus {
+.web-vitals-chrome-extension .lh-root summary:focus {
     outline: none;
     box-shadow: 0 0 0 1px hsl(217, 89%, 61%);
 }
 
-.lh-root [hidden] {
+.web-vitals-chrome-extension .lh-root [hidden] {
   display: none !important;
 }
 
-.lh-root details > summary {
+.web-vitals-chrome-extension .lh-root details > summary {
   cursor: pointer;
 }
 
-.lh-container {
+.web-vitals-chrome-extension .lh-container {
   /*
   Text wrapping in the report is so much FUN!
   We have a `word-break: break-word;` globally here to prevent a few common scenarios, namely
@@ -347,20 +347,21 @@
   word-break: break-word;
 }
 
-.lh-audit-group a,
-.lh-category-header__description a,
-.lh-audit__description a,
-.lh-footer a {
+.web-vitals-chrome-extension .lh-audit-group a,
+.web-vitals-chrome-extension .lh-category-header__description a,
+.web-vitals-chrome-extension .lh-audit__description a,
+.web-vitals-chrome-extension .lh-footer a {
   color: var(--color-informative);
 }
 
-.lh-footer {
+.web-vitals-chrome-extension .lh-footer {
   margin-top: 20px;
   font-size: 12px;
   color: var(--color-gray-500);
 }
 
-.lh-audit__description, .lh-audit__stackpack {
+.web-vitals-chrome-extension .lh-audit__description, 
+.web-vitals-chrome-extension .lh-audit__stackpack {
   --inner-audit-padding-right: var(--stackpack-padding-horizontal);
   padding-left: var(--audit-description-padding-left);
   padding-right: var(--inner-audit-padding-right);
@@ -368,7 +369,7 @@
   padding-bottom: 8px;
 }
 
-.lh-details {
+.web-vitals-chrome-extension .lh-details {
   font-size: var(--report-font-size);
   margin-top: var(--default-padding);
   margin-bottom: var(--default-padding);
@@ -377,51 +378,51 @@
   width: 100%;
 }
 
-.lh-details.flex .lh-code {
+.web-vitals-chrome-extension .lh-details.flex .lh-code {
   max-width: 70%;
 }
 
-.lh-audit__stackpack {
+.web-vitals-chrome-extension .lh-audit__stackpack {
   display: flex;
   align-items: center;
 }
 
-.lh-audit__stackpack__img {
+.web-vitals-chrome-extension .lh-audit__stackpack__img {
   max-width: 50px;
   margin-right: var(--default-padding)
 }
 
 /* Report header */
 
-.report-icon {
+.web-vitals-chrome-extension .report-icon {
   opacity: 0.7;
 }
-.report-icon:hover {
+.web-vitals-chrome-extension .report-icon:hover {
   opacity: 1;
 }
-.report-icon[disabled] {
+.web-vitals-chrome-extension .report-icon[disabled] {
   opacity: 0.3;
   pointer-events: none;
 }
 
-.report-icon--print {
+.web-vitals-chrome-extension .report-icon--print {
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"/><path fill="none" d="M0 0h24v24H0z"/></svg>');
 }
-.report-icon--copy {
+.web-vitals-chrome-extension .report-icon--copy {
   background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>');
 }
-.report-icon--open {
+.web-vitals-chrome-extension .report-icon--open {
   background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h4v-2H5V8h14v10h-4v2h4c1.1 0 2-.9 2-2V6c0-1.1-.89-2-2-2zm-7 6l-4 4h3v6h2v-6h3l-4-4z"/></svg>');
 }
-.report-icon--download {
+.web-vitals-chrome-extension .report-icon--download {
   background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
-.report-icon--dark {
+.web-vitals-chrome-extension .report-icon--dark {
   background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 100 125"><path d="M50 23.587c-16.27 0-22.799 12.574-22.799 21.417 0 12.917 10.117 22.451 12.436 32.471h20.726c2.32-10.02 12.436-19.554 12.436-32.471 0-8.843-6.528-21.417-22.799-21.417zM39.637 87.161c0 3.001 1.18 4.181 4.181 4.181h.426l.41 1.231C45.278 94.449 46.042 95 48.019 95h3.963c1.978 0 2.74-.551 3.365-2.427l.409-1.231h.427c3.002 0 4.18-1.18 4.18-4.181V80.91H39.637v6.251zM50 18.265c1.26 0 2.072-.814 2.072-2.073v-9.12C52.072 5.813 51.26 5 50 5c-1.259 0-2.072.813-2.072 2.073v9.12c0 1.259.813 2.072 2.072 2.072zM68.313 23.727c.994.774 2.135.634 2.91-.357l5.614-7.187c.776-.992.636-2.135-.356-2.909-.992-.776-2.135-.636-2.91.357l-5.613 7.186c-.778.993-.636 2.135.355 2.91zM91.157 36.373c-.306-1.222-1.291-1.815-2.513-1.51l-8.85 2.207c-1.222.305-1.814 1.29-1.51 2.512.305 1.223 1.291 1.814 2.513 1.51l8.849-2.206c1.223-.305 1.816-1.291 1.511-2.513zM86.757 60.48l-8.331-3.709c-1.15-.512-2.225-.099-2.736 1.052-.512 1.151-.1 2.224 1.051 2.737l8.33 3.707c1.15.514 2.225.101 2.736-1.05.513-1.149.1-2.223-1.05-2.737zM28.779 23.37c.775.992 1.917 1.131 2.909.357.992-.776 1.132-1.917.357-2.91l-5.615-7.186c-.775-.992-1.917-1.132-2.909-.357s-1.131 1.917-.356 2.909l5.614 7.187zM21.715 39.583c.305-1.223-.288-2.208-1.51-2.513l-8.849-2.207c-1.222-.303-2.208.289-2.513 1.511-.303 1.222.288 2.207 1.511 2.512l8.848 2.206c1.222.304 2.208-.287 2.513-1.509zM21.575 56.771l-8.331 3.711c-1.151.511-1.563 1.586-1.05 2.735.511 1.151 1.586 1.563 2.736 1.052l8.331-3.711c1.151-.511 1.563-1.586 1.05-2.735-.512-1.15-1.585-1.562-2.736-1.052z"/></svg>');
 }
 
 /* Node */
-.lh-node__snippet {
+.web-vitals-chrome-extension .lh-node__snippet {
   font-family: var(--report-font-family-monospace);
   color: var(--color-teal-600);
   font-size: 12px;
@@ -430,64 +431,64 @@
 
 /* Score */
 
-.lh-audit__score-icon {
+.web-vitals-chrome-extension .lh-audit__score-icon {
   width: var(--score-icon-size);
   height: var(--score-icon-size);
   margin: var(--score-icon-margin);
 }
 
-.lh-audit--pass .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--pass .lh-audit__display-text {
   color: var(--color-pass-secondary);
 }
-.lh-audit--pass .lh-audit__score-icon {
+.web-vitals-chrome-extension .lh-audit--pass .lh-audit__score-icon {
   border-radius: 100%;
   background: var(--color-pass);
 }
 
-.lh-audit--average .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--average .lh-audit__display-text {
   color: var(--color-average-secondary);
 }
-.lh-audit--average .lh-audit__score-icon {
+.web-vitals-chrome-extension .lh-audit--average .lh-audit__score-icon {
   background: var(--color-average);
   width: var(--icon-square-size);
   height: var(--icon-square-size);
 }
 
-.lh-audit--fail .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--fail .lh-audit__display-text {
   color: var(--color-fail-secondary);
 }
-.lh-audit--fail .lh-audit__score-icon,
-.lh-audit--error .lh-audit__score-icon {
+.web-vitals-chrome-extension.lh-audit--fail .lh-audit__score-icon,
+.web-vitals-chrome-extension.lh-audit--error .lh-audit__score-icon {
   border-left: calc(var(--score-icon-size) / 2) solid transparent;
   border-right: calc(var(--score-icon-size) / 2) solid transparent;
   border-bottom: var(--score-icon-size) solid var(--color-fail);
 }
 
-.lh-audit--manual .lh-audit__display-text,
-.lh-audit--notapplicable .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--manual .lh-audit__display-text,
+.web-vitals-chrome-extension .lh-audit--notapplicable .lh-audit__display-text {
   color: var(--color-gray-600);
 }
-.lh-audit--manual .lh-audit__score-icon,
-.lh-audit--notapplicable .lh-audit__score-icon {
+.web-vitals-chrome-extension .lh-audit--manual .lh-audit__score-icon,
+.web-vitals-chrome-extension .lh-audit--notapplicable .lh-audit__score-icon {
   border-radius: 100%;
   background: var(--color-gray-400);
 }
 
-.lh-audit--informative .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--informative .lh-audit__display-text {
   color: var(--color-gray-600);
 }
 
-.lh-audit--informative .lh-audit__score-icon {
+.web-vitals-chrome-extension .lh-audit--informative .lh-audit__score-icon {
   border: none;
   border-radius: 100%;
   background: var(--color-gray-400);
 }
 
-.lh-audit__description,
-.lh-audit__stackpack {
+.web-vitals-chrome-extension .lh-audit__description,
+.web-vitals-chrome-extension .lh-audit__stackpack {
   color: var(--report-text-color-secondary);
 }
-.lh-category-header__description  {
+.web-vitals-chrome-extension .lh-category-header__description  {
   font-size: var(--report-font-size);
   text-align: center;
   margin: 0px auto;
@@ -495,143 +496,142 @@
 }
 
 
-.lh-audit__display-text,
-.lh-load-opportunity__sparkline,
-.lh-chevron-container {
+.web-vitals-chrome-extension .lh-audit__display-text,
+.web-vitals-chrome-extension .lh-load-opportunity__sparkline,
+.web-vitals-chrome-extension .lh-chevron-container {
   margin: 0 var(--audit-margin-horizontal);
 }
-.lh-chevron-container {
+.web-vitals-chrome-extension .lh-chevron-container {
   margin-right: 0;
 }
 
-.lh-audit__title-and-text {
+.web-vitals-chrome-extension .lh-audit__title-and-text {
   flex: 1;
 }
 
 /* Prepend display text with em dash separator. But not in Opportunities. */
-.lh-audit__display-text:not(:empty):before {
+.web-vitals-chrome-extension .lh-audit__display-text:not(:empty):before {
   content: '—';
   margin-right: var(--audit-margin-horizontal);
 }
-.lh-audit-group.lh-audit-group--load-opportunities .lh-audit__display-text:not(:empty):before {
+.web-vitals-chrome-extension .lh-audit-group.lh-audit-group--load-opportunities .lh-audit__display-text:not(:empty):before {
   display: none;
 }
 
 /* Expandable Details (Audit Groups, Audits) */
-.lh-audit__header {
+.web-vitals-chrome-extension .lh-audit__header {
   display: flex;
   align-items: center;
   font-weight: 500;
   padding: var(--audit-padding-vertical) 0;
 }
 
-.lh-audit--load-opportunity .lh-audit__header {
+.web-vitals-chrome-extension .lh-audit--load-opportunity .lh-audit__header {
   display: block;
 }
 
-.lh-audit__header:hover {
+.web-vitals-chrome-extension .lh-audit__header:hover {
   background-color: var(--color-hover);
 }
 
 /* Hide the expandable arrow icon, three ways: via the CSS Counter Styles spec, for webkit/blink browsers, hiding the polyfilled icon */
 /* https://github.com/javan/details-element-polyfill/blob/master/src/details-element-polyfill/polyfill.sass */
-.lh-audit-group > summary,
+.web-vitals-chrome-extension .lh-audit-group > summary,
 .lh-expandable-details > summary {
   list-style-type: none;
 }
-.lh-audit-group > summary::-webkit-details-marker,
+.web-vitals-chrome-extension .lh-audit-group > summary::-webkit-details-marker,
 .lh-expandable-details > summary::-webkit-details-marker {
   display: none;
 }
-.lh-audit-group > summary:before,
-.lh-expandable-details > summary:before {
+.web-vitals-chrome-extension .lh-audit-group > summary:before,
+.web-vitals-chrome-extension .lh-expandable-details > summary:before {
   display: none;
 }
 
 
 /* Perf Metric */
-
-.lh-columns {
+.web-vitals-chrome-extension .lh-columns {
   display: flex;
   width: 100%;
 }
 @media screen and (max-width: 640px) {
-  .lh-columns {
+  .web-vitals-chrome-extension .lh-columns {
     flex-wrap: wrap;
 
   }
 }
 
-.lh-column {
+.web-vitals-chrome-extension .lh-column {
   flex: 1;
 }
-.lh-column:first-of-type {
+.web-vitals-chrome-extension .lh-column:first-of-type {
   margin-right: 24px;
 }
 
 @media screen and (max-width: 800px) {
-  .lh-column:first-of-type {
+  .web-vitals-chrome-extension .lh-column:first-of-type {
     margin-right: 8px;
   }
 }
 @media screen and (max-width: 640px) {
-  .lh-column {
+  .web-vitals-chrome-extension .lh-column {
     flex-basis: 100%;
   }
-  .lh-column:first-of-type {
+  .web-vitals-chrome-extension .lh-column:first-of-type {
     margin-right: 0px;
   }
-  .lh-column:first-of-type .lh-metric:last-of-type {
+  .web-vitals-chrome-extension .lh-column:first-of-type .lh-metric:last-of-type {
     border-bottom: 0;
   }
 }
 
 
-.lh-metric {
+.web-vitals-chrome-extension .lh-metric {
   border-bottom: 1px solid var(--report-border-color-secondary);
 }
-.lh-metric:first-of-type {
+.web-vitals-chrome-extension .lh-metric:first-of-type {
   border-top: 1px solid var(--report-border-color-secondary);
 }
 
-.lh-metric__innerwrap {
+.web-vitals-chrome-extension .lh-metric__innerwrap {
   display: grid;
   grid-template-columns: var(--audit-description-padding-left) 10fr 3fr;
   align-items: center;
   padding: 10px 0;
 }
 
-.lh-metric__details {
+.web-vitals-chrome-extension .lh-metric__details {
   order: -1;
 }
 
-.lh-metric__title {
+.web-vitals-chrome-extension .lh-metric__title {
   flex: 1;
   font-weight: 500;
 }
 
-.lh-metric__subtitle {
+.web-vitals-chrome-extension .lh-metric__subtitle {
   display: block;
   font-weight: 500;
   color: var(--color-gray-500);
 }
 
-.lh-metrics__disclaimer {
+.web-vitals-chrome-extension .lh-metrics__disclaimer {
   color: var(--color-gray-600);
   margin: var(--section-padding-vertical) 0;
 }
-.lh-metrics__disclaimer a {
+.web-vitals-chrome-extension .lh-metrics__disclaimer a {
   color: var(--color-gray-700);
 }
 
-.lh-metric__description {
+.web-vitals-chrome-extension .lh-metric__description {
   display: none;
   grid-column-start: 2;
   grid-column-end: 3;
   color: var(--report-text-color-secondary);
 }
 
-.lh-metric__value {
+.web-vitals-chrome-extension .lh-metric__value {
   white-space: nowrap; /* No wrapping between metric value and the icon */
   font-weight: 500;
   justify-self: end;
@@ -639,11 +639,11 @@
 
 /* No-JS toggle switch */
 /* Keep this selector sync'd w/ `magicSelector` in report-ui-features-test.js */
- .lh-metrics-toggle__input:checked ~ .lh-columns .lh-metric__description {
+.web-vitals-chrome-extension .lh-metrics-toggle__input:checked ~ .lh-columns .lh-metric__description {
   display: block;
 }
 
-.lh-metrics-toggle__input {
+.web-vitals-chrome-extension .lh-metrics-toggle__input {
   cursor: pointer;
   opacity: 0;
   position: absolute;
@@ -652,7 +652,7 @@
   height: 28px;
   top: -3px;
 }
-.lh-metrics-toggle__label {
+.web-vitals-chrome-extension .lh-metrics-toggle__label {
   display: flex;
   background-color: #eee;
   border-radius: 20px;
@@ -662,10 +662,10 @@
   top: -3px;
   pointer-events: none;
 }
-.lh-metrics-toggle__input:focus + label {
+.web-vitals-chrome-extension .lh-metrics-toggle__input:focus + label {
   outline: -webkit-focus-ring-color auto 3px;
 }
-.lh-metrics-toggle__icon {
+.web-vitals-chrome-extension .lh-metrics-toggle__icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -673,35 +673,35 @@
   width: 50%;
   height: 28px;
 }
-.lh-metrics-toggle__input:not(:checked) + label .lh-metrics-toggle__icon--less,
-.lh-metrics-toggle__input:checked + label .lh-metrics-toggle__icon--more {
+.web-vitals-chrome-extension .lh-metrics-toggle__input:not(:checked) + label .lh-metrics-toggle__icon--less,
+.web-vitals-chrome-extension .lh-metrics-toggle__input:checked + label .lh-metrics-toggle__icon--more {
   background-color: var(--color-blue-A700);
   --metric-toggle-lines-fill: var(--color-white);
 }
-.lh-metrics-toggle__lines {
+.web-vitals-chrome-extension .lh-metrics-toggle__lines {
   fill: var(--metric-toggle-lines-fill);
 }
 
-.lh-metrics-toggle__label  {
+.web-vitals-chrome-extension .lh-metrics-toggle__label  {
   background-color: var(--metrics-toggle-background-color);
 }
 
-.lh-metrics-toggle__label .lh-metrics-toggle__icon--less {
+.web-vitals-chrome-extension .lh-metrics-toggle__label .lh-metrics-toggle__icon--less {
   padding-left: 8px;
 }
-.lh-metrics-toggle__label .lh-metrics-toggle__icon--more {
+.web-vitals-chrome-extension .lh-metrics-toggle__label .lh-metrics-toggle__icon--more {
   padding-right: 8px;
 }
 
 /* Pushes the metric description toggle button to the right. */
-.lh-audit-group--metrics .lh-audit-group__header {
+.web-vitals-chrome-extension .lh-audit-group--metrics .lh-audit-group__header {
   display: flex;
 }
-.lh-audit-group--metrics .lh-audit-group__header span.lh-audit-group__title {
+.web-vitals-chrome-extension .lh-audit-group--metrics .lh-audit-group__header span.lh-audit-group__title {
   flex: 1;
 }
 
-.lh-metric .lh-metric__innerwrap::before {
+.web-vitals-chrome-extension .lh-metric .lh-metric__innerwrap::before {
   content: '';
   width: var(--score-icon-size);
   height: var(--score-icon-size);
@@ -709,66 +709,65 @@
   margin: var(--score-icon-margin);
 }
 
-.lh-metric--pass .lh-metric__value {
+.web-vitals-chrome-extension .lh-metric--pass .lh-metric__value {
   color: var(--color-pass-secondary);
 }
-.lh-metric--pass .lh-metric__innerwrap::before {
+.web-vitals-chrome-extension .lh-metric--pass .lh-metric__innerwrap::before {
   border-radius: 100%;
   background: var(--color-pass);
 }
 
-.lh-metric--average .lh-metric__value {
+.web-vitals-chrome-extension .lh-metric--average .lh-metric__value {
   color: var(--color-average-secondary);
 }
-.lh-metric--average .lh-metric__innerwrap::before {
+.web-vitals-chrome-extension .lh-metric--average .lh-metric__innerwrap::before {
   background: var(--color-average);
   width: var(--icon-square-size);
   height: var(--icon-square-size);
 }
 
-.lh-metric--fail .lh-metric__value {
+.web-vitals-chrome-extension .lh-metric--fail .lh-metric__value {
   color: var(--color-fail-secondary);
 }
-.lh-metric--fail .lh-metric__innerwrap::before,
-.lh-metric--error .lh-metric__innerwrap::before {
+.web-vitals-chrome-extension .lh-metric--fail .lh-metric__innerwrap::before,
+.web-vitals-chrome-extension .lh-metric--error .lh-metric__innerwrap::before {
   border-left: calc(var(--score-icon-size) / 2) solid transparent;
   border-right: calc(var(--score-icon-size) / 2) solid transparent;
   border-bottom: var(--score-icon-size) solid var(--color-fail);
 }
 
-.lh-metric--error .lh-metric__value,
-.lh-metric--error .lh-metric__description {
+.web-vitals-chrome-extension .lh-metric--error .lh-metric__value,
+.web-vitals-chrome-extension .lh-metric--error .lh-metric__description {
   color: var(--color-fail-secondary);
 }
 
 /* Perf load opportunity */
-
-.lh-load-opportunity__cols {
+.web-vitals-chrome-extension .lh-load-opportunity__cols {
   display: flex;
   align-items: flex-start;
 }
 
-.lh-load-opportunity__header .lh-load-opportunity__col {
+.web-vitals-chrome-extension .lh-load-opportunity__header .lh-load-opportunity__col {
   color: var(--color-gray-600);
   display: unset;
   line-height: calc(2.3 * var(--report-font-size));
 }
 
-.lh-load-opportunity__col {
+.web-vitals-chrome-extension .lh-load-opportunity__col {
   display: flex;
 }
 
-.lh-load-opportunity__col--one {
+.web-vitals-chrome-extension .lh-load-opportunity__col--one {
   flex: 5;
   align-items: center;
   margin-right: 2px;
 }
-.lh-load-opportunity__col--two {
+.web-vitals-chrome-extension .lh-load-opportunity__col--two {
   flex: 4;
   text-align: right;
 }
 
-.lh-audit--load-opportunity .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--load-opportunity .lh-audit__display-text {
   text-align: right;
   flex: 0 0 calc(3 * var(--report-font-size));
 }
@@ -776,17 +775,17 @@
 
 /* Sparkline */
 
-.lh-load-opportunity__sparkline {
+.web-vitals-chrome-extension .lh-load-opportunity__sparkline {
   flex: 1;
   margin-top: calc((var(--report-line-height) - var(--sparkline-height)) / 2);
 }
 
-.lh-sparkline {
+.web-vitals-chrome-extension .lh-sparkline {
   height: var(--sparkline-height);
   width: 100%;
 }
 
-.lh-sparkline__bar {
+.web-vitals-chrome-extension .lh-sparkline__bar {
   height: 100%;
   float: right;
 }
@@ -795,50 +794,49 @@
   background: var(--color-pass);
 }
 
-.lh-audit--average .lh-sparkline__bar {
+.web-vitals-chrome-extension .lh-audit--average .lh-sparkline__bar {
   background: var(--color-average);
 }
 
-.lh-audit--fail .lh-sparkline__bar {
+.web-vitals-chrome-extension .lh-audit--fail .lh-sparkline__bar {
   background: var(--color-fail);
 }
 
 
 
 /* Filmstrip */
-
-.lh-filmstrip-container {
+.web-vitals-chrome-extension .lh-filmstrip-container {
   /* smaller gap between metrics and filmstrip */
   margin: -8px auto 0 auto;
 }
 
-.lh-filmstrip {
+.web-vitals-chrome-extension .lh-filmstrip {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   padding-bottom: var(--default-padding);
 }
 
-.lh-filmstrip__frame {
+.web-vitals-chrome-extension .lh-filmstrip__frame {
   text-align: right;
   position: relative;
 }
 
-.lh-filmstrip__thumbnail {
+.web-vitals-chrome-extension .lh-filmstrip__thumbnail {
   border: 1px solid var(--report-border-color-secondary);
   max-height: 100px;
   max-width: 60px;
 }
 
 @media screen and (max-width: 750px) {
-  .lh-filmstrip {
+  .web-vitals-chrome-extension .lh-filmstrip {
     flex-wrap: wrap;
   }
-  .lh-filmstrip__frame {
+  .web-vitals-chrome-extension .lh-filmstrip__frame {
     width: 20%;
     margin-bottom: 5px;
   }
-  .lh-filmstrip__thumbnail {
+  .web-vitals-chrome-extension .lh-filmstrip__thumbnail {
     display: block;
     margin: auto;
   }
@@ -846,30 +844,30 @@
 
 /* Audit */
 
-.lh-audit {
+.web-vitals-chrome-extension .lh-audit {
   border-bottom: 1px solid var(--report-border-color-secondary);
 }
 
 /* Apply border-top to just the first audit. */
-.lh-audit {
+.web-vitals-chrome-extension .lh-audit {
   border-top: 1px solid var(--report-border-color-secondary);
 }
-.lh-audit ~ .lh-audit {
+.web-vitals-chrome-extension .lh-audit ~ .lh-audit {
   border-top: none;
 }
 
 
-.lh-audit--error .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--error .lh-audit__display-text {
   color: var(--color-fail);
 }
 
 /* Audit Group */
 
-.lh-audit-group {
+.web-vitals-chrome-extension .lh-audit-group {
   position: relative;
 }
 
-.lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group__header::before {
   /* By default, groups don't get an icon */
   content: none;
   width: var(--pwa-icon-size);
@@ -880,148 +878,148 @@
 }
 
 /* Style the "over budget" columns red. */
-.lh-audit-group--budgets .lh-table tbody tr td:nth-child(4),
-.lh-audit-group--budgets .lh-table tbody tr td:nth-child(5){
+.web-vitals-chrome-extension .lh-audit-group--budgets .lh-table tbody tr td:nth-child(4),
+.web-vitals-chrome-extension .lh-audit-group--budgets .lh-table tbody tr td:nth-child(5){
   color: var(--color-red-700);
 }
 
 /* Align the "over budget request count" text to be close to the "over budget bytes" column. */
-.lh-audit-group--budgets .lh-table tbody tr td:nth-child(4){
+.web-vitals-chrome-extension .lh-audit-group--budgets .lh-table tbody tr td:nth-child(4){
   text-align: right;
 }
 
-.lh-audit-group--budgets .lh-table {
+.web-vitals-chrome-extension .lh-audit-group--budgets .lh-table {
   width: 100%;
 }
 
-.lh-audit-group--pwa-fast-reliable .lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group--pwa-fast-reliable .lh-audit-group__header::before {
   content: '';
   background-image: var(--pwa-fast-reliable-gray-url);
 }
-.lh-audit-group--pwa-installable .lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group--pwa-installable .lh-audit-group__header::before {
   content: '';
   background-image: var(--pwa-installable-gray-url);
 }
-.lh-audit-group--pwa-optimized .lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group--pwa-optimized .lh-audit-group__header::before {
   content: '';
   background-image: var(--pwa-optimized-gray-url);
 }
-.lh-audit-group--pwa-fast-reliable.lh-badged .lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group--pwa-fast-reliable.lh-badged .lh-audit-group__header::before {
   background-image: var(--pwa-fast-reliable-color-url);
 }
-.lh-audit-group--pwa-installable.lh-badged .lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group--pwa-installable.lh-badged .lh-audit-group__header::before {
   background-image: var(--pwa-installable-color-url);
 }
-.lh-audit-group--pwa-optimized.lh-badged .lh-audit-group__header::before {
+.web-vitals-chrome-extension .lh-audit-group--pwa-optimized.lh-badged .lh-audit-group__header::before {
   background-image: var(--pwa-optimized-color-url);
 }
 
-.lh-audit-group--metrics .lh-audit-group__summary {
+.web-vitals-chrome-extension .lh-audit-group--metrics .lh-audit-group__summary {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.lh-audit-group__summary {
+.web-vitals-chrome-extension .lh-audit-group__summary {
   display: flex;
   justify-content: space-between;
   margin-top: calc(var(--category-padding) * 1.5);
   margin-bottom: var(--category-padding);
 }
 
-.lh-audit-group__itemcount {
+.web-vitals-chrome-extension .lh-audit-group__itemcount {
   color: var(--color-gray-600);
   font-weight: bold;
 }
-.lh-audit-group__header .lh-chevron {
+.web-vitals-chrome-extension .lh-audit-group__header .lh-chevron {
   margin-top: calc((var(--report-line-height) - 5px) / 2);
 }
 
-.lh-audit-group__header {
+.web-vitals-chrome-extension .lh-audit-group__header {
   font-size: var(--report-font-size);
   margin: 0 0 var(--audit-group-padding-vertical);
   /* When the header takes 100% width, the chevron becomes small. */
   max-width: calc(100% - var(--chevron-size));
 }
 /* max-width makes the metric toggle not flush. metrics doesn't have a chevron so unset. */
-.lh-audit-group--metrics .lh-audit-group__header {
+.web-vitals-chrome-extension .lh-audit-group--metrics .lh-audit-group__header {
   max-width: unset;
 }
 
-.lh-audit-group__header span.lh-audit-group__title {
+.web-vitals-chrome-extension .lh-audit-group__header span.lh-audit-group__title {
   font-weight: bold;
 }
 
-.lh-audit-group__header span.lh-audit-group__itemcount {
+.web-vitals-chrome-extension .lh-audit-group__header span.lh-audit-group__itemcount {
   font-weight: bold;
   color: var(--color-gray-600);
 }
 
-.lh-audit-group__header span.lh-audit-group__description {
+.web-vitals-chrome-extension .lh-audit-group__header span.lh-audit-group__description {
   font-weight: 500;
   color: var(--color-gray-600);
 }
-.lh-audit-group__header span.lh-audit-group__description::before {
+.web-vitals-chrome-extension .lh-audit-group__header span.lh-audit-group__description::before {
   content: '—';
   margin: 0px var(--audit-margin-horizontal);
 }
 
-.lh-clump > .lh-audit-group__header,
-.lh-audit-group--diagnostics .lh-audit-group__header,
-.lh-audit-group--load-opportunities .lh-audit-group__header,
-.lh-audit-group--metrics .lh-audit-group__header,
-.lh-audit-group--pwa-fast-reliable .lh-audit-group__header,
-.lh-audit-group--pwa-installable .lh-audit-group__header,
-.lh-audit-group--pwa-optimized .lh-audit-group__header {
+.web-vitals-chrome-extension .lh-clump > .lh-audit-group__header,
+.web-vitals-chrome-extension .lh-audit-group--diagnostics .lh-audit-group__header,
+.web-vitals-chrome-extension .lh-audit-group--load-opportunities .lh-audit-group__header,
+.web-vitals-chrome-extension .lh-audit-group--metrics .lh-audit-group__header,
+.web-vitals-chrome-extension .lh-audit-group--pwa-fast-reliable .lh-audit-group__header,
+.web-vitals-chrome-extension .lh-audit-group--pwa-installable .lh-audit-group__header,
+.web-vitals-chrome-extension .lh-audit-group--pwa-optimized .lh-audit-group__header {
   margin-top: var(--audit-group-padding-vertical);
 }
 
-.lh-audit-explanation {
+.web-vitals-chrome-extension .lh-audit-explanation {
   margin: var(--audit-padding-vertical) 0 calc(var(--audit-padding-vertical) / 2) var(--audit-margin-horizontal);
   line-height: var(--audit-explanation-line-height);
   display: inline-block;
 }
 
-.lh-audit--fail .lh-audit-explanation {
+.web-vitals-chrome-extension .lh-audit--fail .lh-audit-explanation {
   color: var(--color-fail);
 }
 
 /* Report */
-.lh-list > div:not(:last-child) {
+.web-vitals-chrome-extension .lh-list > div:not(:last-child) {
   padding-bottom: 20px;
 }
 
-.lh-header-container {
+.web-vitals-chrome-extension .lh-header-container {
   display: block;
   margin: 0 auto;
   position: relative;
   word-wrap: break-word;
 }
 
-.lh-report {
+.web-vitals-chrome-extension .lh-report {
   min-width: var(--report-min-width);
 }
 
-.lh-exception {
+.web-vitals-chrome-extension .lh-exception {
   font-size: large;
 }
 
-.lh-code {
+.web-vitals-chrome-extension .lh-code {
   white-space: normal;
   margin-top: 0;
   font-size: 85%;
 }
 
-.lh-warnings {
+.web-vitals-chrome-extension .lh-warnings {
   --item-margin: calc(var(--report-line-height) / 6);
   color: var(--color-average);
   margin: var(--audit-padding-vertical) 0;
   padding: calc(var(--audit-padding-vertical) / 2) var(--audit-padding-vertical);
 }
-.lh-warnings span {
+.web-vitals-chrome-extension .lh-warnings span {
   font-weight: bold;
 }
 
-.lh-warnings--toplevel {
+.web-vitals-chrome-extension .lh-warnings--toplevel {
   --item-margin: calc(var(--header-line-height) / 4);
   color: var(--report-text-color-secondary);
   margin-left: auto;
@@ -1031,64 +1029,64 @@
   padding: var(--toplevel-warning-padding);
 }
 
-.lh-warnings ul {
+.web-vitals-chrome-extension .lh-warnings ul {
   padding-left: calc(var(--category-padding) * 2);
   margin: 0;
 }
-.lh-warnings li {
+.web-vitals-chrome-extension .lh-warnings li {
   margin: var(--item-margin) 0;
 }
-.lh-warnings li:last-of-type {
+.web-vitals-chrome-extension .lh-warnings li:last-of-type {
   margin-bottom: 0;
 }
 
-.lh-scores-header {
+.web-vitals-chrome-extension .lh-scores-header {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
 }
-.lh-scores-header__solo {
+.web-vitals-chrome-extension .lh-scores-header__solo {
   padding: 0;
   border: 0;
 }
 
 /* Gauge */
 
-.lh-gauge__wrapper--pass {
+.web-vitals-chrome-extension .lh-gauge__wrapper--pass {
   color: var(--color-pass);
   fill: var(--color-pass);
   stroke: var(--color-pass);
 }
 
-.lh-gauge__wrapper--average {
+.web-vitals-chrome-extension .lh-gauge__wrapper--average {
   color: var(--color-average);
   fill: var(--color-average);
   stroke: var(--color-average);
 }
 
-.lh-gauge__wrapper--fail {
+.web-vitals-chrome-extension .lh-gauge__wrapper--fail {
   color: var(--color-fail);
   fill: var(--color-fail);
   stroke: var(--color-fail);
 }
 
-.lh-gauge {
+.web-vitals-chrome-extension .lh-gauge {
   stroke-linecap: round;
   width: var(--gauge-circle-size);
   height: var(--gauge-circle-size);
 }
 
-.lh-category .lh-gauge {
+.web-vitals-chrome-extension .lh-category .lh-gauge {
   --gauge-circle-size: var(--gauge-circle-size-big);
 }
 
-.lh-gauge-base {
+.web-vitals-chrome-extension .lh-gauge-base {
     opacity: 0.1;
     stroke: var(--circle-background);
     stroke-width: var(--circle-border-width);
 }
 
-.lh-gauge-arc {
+.web-vitals-chrome-extension .lh-gauge-arc {
     fill: none;
     stroke: var(--circle-color);
     stroke-width: var(--circle-border-width);
@@ -1096,16 +1094,16 @@
     animation-delay: 250ms;
 }
 
-.lh-gauge__svg-wrapper {
+.web-vitals-chrome-extension .lh-gauge__svg-wrapper {
   position: relative;
   height: var(--gauge-circle-size);
 }
-.lh-category .lh-gauge__svg-wrapper {
+.web-vitals-chrome-extension .lh-category .lh-gauge__svg-wrapper {
   --gauge-circle-size: var(--gauge-circle-size-big);
 }
 
 /* The plugin badge overlay */
-.lh-gauge__wrapper--plugin .lh-gauge__svg-wrapper::before {
+.web-vitals-chrome-extension .lh-gauge__wrapper--plugin .lh-gauge__svg-wrapper::before {
   width: var(--plugin-badge-size);
   height: var(--plugin-badge-size);
   background-color: var(--plugin-badge-background-color);
@@ -1122,7 +1120,7 @@
   box-shadow: 0 0 4px rgba(0,0,0,.2);
   border-radius: 25%;
 }
-.lh-category .lh-gauge__wrapper--plugin .lh-gauge__svg-wrapper::before {
+.web-vitals-chrome-extension .lh-category .lh-gauge__wrapper--plugin .lh-gauge__svg-wrapper::before {
   width: var(--plugin-badge-size-big);
   height: var(--plugin-badge-size-big);
 }
@@ -1131,7 +1129,7 @@
   from { stroke-dasharray: 0 352; }
 }
 
-.lh-gauge__percentage {
+.web-vitals-chrome-extension .lh-gauge__percentage {
   width: 100%;
   height: var(--gauge-circle-size);
   position: absolute;
@@ -1142,12 +1140,12 @@
   top: calc(var(--score-container-padding) + var(--gauge-circle-size) / 2);
 }
 
-.lh-category .lh-gauge__percentage {
+.web-vitals-chrome-extension .lh-category .lh-gauge__percentage {
   --gauge-circle-size: var(--gauge-circle-size-big);
   --gauge-percentage-font-size: var(--gauge-percentage-font-size-big);
 }
 
-.lh-gauge__wrapper {
+.web-vitals-chrome-extension .lh-gauge__wrapper {
   position: relative;
   display: flex;
   align-items: center;
@@ -1163,7 +1161,7 @@
   will-change: opacity; /* Only using for layer promotion */
 }
 
-.lh-gauge__label {
+.web-vitals-chrome-extension .lh-gauge__label {
   font-size: var(--gauge-label-font-size);
   line-height: var(--gauge-label-line-height);
   margin-top: 10px;
@@ -1172,21 +1170,21 @@
 }
 
 /* TODO(#8185) use more BEM (.lh-gauge__label--big) instead of relying on descendant selector */
-.lh-category .lh-gauge__label {
+.web-vitals-chrome-extension .lh-category .lh-gauge__label {
   --gauge-label-font-size: var(--gauge-label-font-size-big);
   --gauge-label-line-height: var(--gauge-label-line-height-big);
   margin-top: 14px;
 }
 
 
-.lh-scores-header .lh-gauge__wrapper,
-.lh-scores-header .lh-gauge--pwa__wrapper,
-.lh-sticky-header .lh-gauge__wrapper,
-.lh-sticky-header .lh-gauge--pwa__wrapper {
+.web-vitals-chrome-extension .lh-scores-header .lh-gauge__wrapper,
+.web-vitals-chrome-extension .lh-scores-header .lh-gauge--pwa__wrapper,
+.web-vitals-chrome-extension .lh-sticky-header .lh-gauge__wrapper,
+.web-vitals-chrome-extension .lh-sticky-header .lh-gauge--pwa__wrapper {
   width: var(--gauge-wrapper-width);
 }
 
-.lh-scorescale {
+.web-vitals-chrome-extension .lh-scorescale {
   display: inline-flex;
   margin: 12px auto 0 auto;
   border: 1px solid var(--color-gray-200);
@@ -1194,7 +1192,7 @@
   padding: 8px 8px;
 }
 
-.lh-scorescale-range {
+.web-vitals-chrome-extension .lh-scorescale-range {
   display: flex;
   align-items: center;
   margin: 0 12px;
@@ -1202,7 +1200,7 @@
   white-space: nowrap;
 }
 
-.lh-scorescale-range::before {
+.web-vitals-chrome-extension .lh-scorescale-range::before {
   content: '';
   width: var(--scorescale-width);
   height: var(--scorescale-height);
@@ -1211,46 +1209,46 @@
   margin-right: 10px;
 }
 
-.lh-scorescale-range--pass::before {
+.web-vitals-chrome-extension .lh-scorescale-range--pass::before {
   background-color: var(--color-pass);
 }
 
-.lh-scorescale-range--average::before {
+.web-vitals-chrome-extension .lh-scorescale-range--average::before {
   background-color: var(--color-average);
 }
 
-.lh-scorescale-range--fail::before {
+.web-vitals-chrome-extension .lh-scorescale-range--fail::before {
   background-color: var(--color-fail);
 }
 
 /* Hide category score gauages if it's a single category report */
-.lh-header--solo-category .lh-scores-wrapper {
+.web-vitals-chrome-extension .lh-header--solo-category .lh-scores-wrapper {
   display: none;
 }
 
 
-.lh-categories {
+.web-vitals-chrome-extension .lh-categories {
   width: 100%;
 }
 
-.lh-category {
+.web-vitals-chrome-extension .lh-category {
   padding: var(--category-padding);
   max-width: var(--report-width);
   margin: 0 auto;
 }
 
-.lh-category-wrapper {
+.web-vitals-chrome-extension .lh-category-wrapper {
   border-bottom: 1px solid var(--color-gray-200);
 }
 
-.lh-category-wrapper:first-of-type {
+.web-vitals-chrome-extension .lh-category-wrapper:first-of-type {
   border-top: 1px solid var(--color-gray-200);
 }
 
 /* section hash link jump should preserve fixed header
    https://css-tricks.com/hash-tag-links-padding/
 */
-.lh-category > .lh-permalink {
+.web-vitals-chrome-extension .lh-category > .lh-permalink {
   --sticky-header-height: calc(var(--gauge-circle-size) + var(--score-container-padding) * 2);
   --topbar-plus-header: calc(var(--topbar-height) + var(--sticky-header-height));
   margin-top: calc(var(--topbar-plus-header) * -1);
@@ -1259,24 +1257,24 @@
   visibility: hidden;
 }
 
-.lh-category-header {
+.web-vitals-chrome-extension .lh-category-header {
   font-size: var(--category-header-font-size);
   min-height: var(--gauge-circle-size);
   margin-bottom: var(--section-padding-vertical);
 }
 
-.lh-category-header .lh-score__gauge {
+.web-vitals-chrome-extension .lh-category-header .lh-score__gauge {
   max-width: 400px;
   width: auto;
   margin: 0px auto;
 }
 
-.lh-category-header .lh-audit__title {
+.web-vitals-chrome-extension .lh-category-header .lh-audit__title {
   font-size: var(--category-header-font-size);
   line-height: var(--header-line-height);
 }
 
-#lh-log {
+.web-vitals-chrome-extension #lh-log {
   position: fixed;
   background-color: #323232;
   color: #fff;
@@ -1296,14 +1294,14 @@
   z-index: 3;
 }
 
-#lh-log.show {
+.web-vitals-chrome-extension #lh-log.show {
   opacity: 1;
   transform: translateY(0);
 }
 
 /* 964 fits the min-width of the filmstrip */
 @media screen and (max-width: 964px) {
-  .lh-report {
+  .web-vitals-chrome-extension .lh-report {
     margin-left: 0;
     width: 100%;
   }
@@ -1313,121 +1311,121 @@
   body {
     -webkit-print-color-adjust: exact; /* print background colors */
   }
-  .lh-container {
+  .web-vitals-chrome-extension .lh-container {
     display: block;
   }
-  .lh-report {
+  .web-vitals-chrome-extension .lh-report {
     margin-left: 0;
     padding-top: 0;
   }
-  .lh-categories {
+  .web-vitals-chrome-extension .lh-categories {
     margin-top: 0;
   }
 }
 
-.lh-table {
+.web-vitals-chrome-extension .lh-table {
   border-collapse: collapse;
   /* Can't assign padding to table, so shorten the width instead. */
   width: calc(100% - var(--audit-description-padding-left));
 }
 
-.lh-table thead th {
+.web-vitals-chrome-extension .lh-table thead th {
   font-weight: normal;
   color: var(--color-gray-600);
   /* See text-wrapping comment on .lh-container. */
   word-break: normal;
 }
 
-.lh-table tbody tr:nth-child(odd) {
+.web-vitals-chrome-extension .lh-table tbody tr:nth-child(odd) {
   background-color: var(--table-higlight-background-color);
 }
 
-.lh-table th,
-.lh-table td {
+.web-vitals-chrome-extension .lh-table th,
+.web-vitals-chrome-extension .lh-table td {
   padding: 8px 6px;
 }
-.lh-table th:first-child {
+.web-vitals-chrome-extension .lh-table th:first-child {
   padding-left: 0;
 }
-.lh-table th:last-child {
+.web-vitals-chrome-extension .lh-table th:last-child {
   padding-right: 0;
 }
 
 /* Looks unnecessary, but mostly for keeping the <th>s left-aligned */
-.lh-table-column--text,
-.lh-table-column--url,
+.web-vitals-chrome-extension .lh-table-column--text,
+.web-vitals-chrome-extension .lh-table-column--url,
 /* .lh-table-column--thumbnail, */
 /* .lh-table-column--empty,*/
-.lh-table-column--code,
-.lh-table-column--node {
+.web-vitals-chrome-extension .lh-table-column--code,
+.web-vitals-chrome-extension .lh-table-column--node {
   text-align: left;
 }
 
-.lh-table-column--bytes,
-.lh-table-column--timespanMs,
-.lh-table-column--ms,
-.lh-table-column--numeric {
+.web-vitals-chrome-extension .lh-table-column--bytes,
+.web-vitals-chrome-extension .lh-table-column--timespanMs,
+.web-vitals-chrome-extension .lh-table-column--ms,
+.web-vitals-chrome-extension .lh-table-column--numeric {
   text-align: right;
   word-break: normal;
 }
 
 
 
-.lh-table .lh-table-column--thumbnail {
+.web-vitals-chrome-extension .lh-table .lh-table-column--thumbnail {
   width: var(--image-preview-size);
   padding: 0;
 }
 
-.lh-table-column--url {
+.web-vitals-chrome-extension .lh-table-column--url {
   min-width: 250px;
 }
 
 /* Keep columns narrow if they follow the URL column */
 /* 12% was determined to be a decent narrow width, but wide enough for column headings */
-.lh-table-column--url + th.lh-table-column--bytes,
-.lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
-.lh-table-column--url + .lh-table-column--ms,
-.lh-table-column--url + .lh-table-column--ms + th.lh-table-column--bytes,
-.lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
+.web-vitals-chrome-extension .lh-table-column--url + th.lh-table-column--bytes,
+.web-vitals-chrome-extension .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
+.web-vitals-chrome-extension .lh-table-column--url + .lh-table-column--ms,
+.web-vitals-chrome-extension .lh-table-column--url + .lh-table-column--ms + th.lh-table-column--bytes,
+.web-vitals-chrome-extension .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
   width: 12%;
 }
 
 
-.lh-text__url-host {
+.web-vitals-chrome-extension .lh-text__url-host {
   display: inline;
 }
 
-.lh-text__url-host {
+.web-vitals-chrome-extension .lh-text__url-host {
   margin-left: calc(var(--report-font-size) / 2);
   opacity: 0.6;
   font-size: 90%
 }
 
-.lh-thumbnail {
+.web-vitals-chrome-extension .lh-thumbnail {
   object-fit: cover;
   width: var(--image-preview-size);
   height: var(--image-preview-size);
   display: block;
 }
 
-.lh-unknown pre {
+.web-vitals-chrome-extension .lh-unknown pre {
   overflow: scroll;
   border: solid 1px var(--color-gray-200);
 }
 
-.lh-text__url > a {
+.web-vitals-chrome-extension .lh-text__url > a {
   color: inherit;
   text-decoration: none;
 }
 
-.lh-text__url > a:hover {
+.web-vitals-chrome-extension .lh-text__url > a:hover {
   text-decoration: underline dotted #999;
 }
 
 /* Chevron
    https://codepen.io/paulirish/pen/LmzEmK
  */
-.lh-chevron {
+ .web-vitals-chrome-extension .lh-chevron {
   --chevron-angle: 42deg;
   /* Edge doesn't support transform: rotate(calc(...)), so we define it here */
   --chevron-angle-right: -42deg;
@@ -1436,11 +1434,11 @@
   margin-top: calc((var(--report-line-height) - 12px) / 2);
 }
 
-.lh-chevron__lines {
+.web-vitals-chrome-extension .lh-chevron__lines {
   transition: transform 0.4s;
   transform: translateY(var(--report-line-height));
 }
-.lh-chevron__line {
+.web-vitals-chrome-extension .lh-chevron__line {
  stroke: var(--chevron-line-stroke);
  stroke-width: var(--chevron-size);
  stroke-linecap: square;
@@ -1449,31 +1447,31 @@
  transition: transform 300ms, stroke 300ms;
 }
 
-.lh-audit-group > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
-.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-left,
-.lh-audit > .lh-expandable-details .lh-chevron__line-right,
-.lh-audit > .lh-expandable-details[open] .lh-chevron__line-left {
+.web-vitals-chrome-extension .lh-audit-group > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
+.web-vitals-chrome-extension .lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-left,
+.web-vitals-chrome-extension .lh-audit > .lh-expandable-details .lh-chevron__line-right,
+.web-vitals-chrome-extension .lh-audit > .lh-expandable-details[open] .lh-chevron__line-left {
  transform: rotate(var(--chevron-angle-right));
 }
 
-.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
-.lh-audit > .lh-expandable-details[open] .lh-chevron__line-right {
+.web-vitals-chrome-extension .lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
+.web-vitals-chrome-extension .lh-audit > .lh-expandable-details[open] .lh-chevron__line-right {
   transform: rotate(var(--chevron-angle));
 }
 
-.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__lines,
-.lh-audit > .lh-expandable-details[open] .lh-chevron__lines {
+.web-vitals-chrome-extension .lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__lines,
+.web-vitals-chrome-extension .lh-audit > .lh-expandable-details[open] .lh-chevron__lines {
  transform: translateY(calc(var(--chevron-size) * -1));
 }
 
 
 
 /* Tooltip */
-.tooltip-boundary {
+.web-vitals-chrome-extension .tooltip-boundary {
   position: relative;
 }
 
-.tooltip {
+.web-vitals-chrome-extension .tooltip {
   position: absolute;
   display: none; /* Don't retain these layers when not needed */
   opacity: 0;
@@ -1488,17 +1486,17 @@
    45vw is chosen to be ~= width of the left column of metrics
 */
 @media screen and (max-width: 535px) {
-  .tooltip {
+  .web-vitals-chrome-extension .tooltip {
     min-width: 45vw;
     padding: 3vw;
   }
 }
 
-.tooltip-boundary:hover {
+.web-vitals-chrome-extension .tooltip-boundary:hover {
   background-color: var(--color-hover);
 }
 
-.tooltip-boundary:hover .tooltip {
+.web-vitals-chrome-extension .tooltip-boundary:hover .tooltip {
   display: block;
   animation: fadeInTooltip 250ms;
   animation-fill-mode: forwards;
@@ -1510,7 +1508,7 @@
   pointer-events: none;
 }
 
-.tooltip::before {
+.web-vitals-chrome-extension .tooltip::before {
   content: "";
   border: solid transparent;
   border-bottom-color: #fff;
@@ -1537,7 +1535,7 @@
   --lh-background-color: #304ffe;
 }
 
-.drop_zone {
+.web-vitals-chrome-extension .drop_zone {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1548,13 +1546,13 @@
   bottom: 0;
   visibility: hidden;
 }
-.drop_zone.dropping {
+.web-vitals-chrome-extension .drop_zone.dropping {
   visibility: visible;
   font-size: var(--heading-font-size);
   background-color: rgba(255,255,255,0.8);
   color: var(--unknown-color);
 }
-.drop_zone.dropping::after {
+.web-vitals-chrome-extension .drop_zone.dropping::after {
   content: 'Drop report here';
   border: 2px dashed currentColor;
   border-radius: 5px;
@@ -1567,7 +1565,7 @@
   justify-content: center;
   background-color: #fff;
 }
-.viewer-placeholder {
+.web-vitals-chrome-extension .viewer-placeholder {
   height: 100vh;
   display: flex;
   align-items: center;
@@ -1575,7 +1573,7 @@
   color: #555;
   font-weight: 300;
 }
-.viewer-placeholder-inner {
+.web-vitals-chrome-extension .viewer-placeholder-inner {
   display: flex;
   align-items: center;
   border-radius: 5px;
@@ -1585,77 +1583,77 @@
   cursor: pointer;
   background-color: #fff;
 }
-.viewer-placeholder-inner.lh-loading {
+.web-vitals-chrome-extension .viewer-placeholder-inner.lh-loading {
   filter: blur(2px) grayscale(1);
   pointer-events: none;
   cursor: wait
 }
-.viewer-placeholder-inner.dropping {
+.web-vitals-chrome-extension .viewer-placeholder-inner.dropping {
   border-color: currentColor;
 }
-.viewer-placeholder__heading {
+.web-vitals-chrome-extension .viewer-placeholder__heading {
   font-weight: 300;
   margin: 0;
 }
-.viewer-placeholder__help {
+.web-vitals-chrome-extension .viewer-placeholder__help {
   margin-top: 12px;
   line-height: 1.6;
 }
-.viewer-placeholder-logo {
+.web-vitals-chrome-extension .viewer-placeholder-logo {
   width: 140px;
   height: 140px;
 }
-.viewer-placeholder__url {
+.web-vitals-chrome-extension .viewer-placeholder__url {
   padding: 8px;
   width: 100%;
   border: 1px solid #eee;
   margin-top: 16px;
   display: none;
 }
-.share:disabled {
+.web-vitals-chrome-extension .share:disabled {
   opacity: 0.2;
   cursor: default;
 }
 
 @media screen and (max-width: 635px) {
-  .viewer-placeholder-inner {
+  .web-vitals-chrome-extension .viewer-placeholder-inner {
     display: block;
     text-align: center;
   }
-  .viewer-placeholder-logo {
+  .web-vitals-chrome-extension .viewer-placeholder-logo {
     width: 100px;
     height: 100px;
   }
-  .viewer-placeholder__url {
+  .web-vitals-chrome-extension .viewer-placeholder__url {
     display: block;
   }
 }
 
 @media screen and (min-width: 636px) {
-  .viewer-placeholder-inner {
+  .web-vitals-chrome-extension .viewer-placeholder-inner {
     padding: 40px 32px;
   }
-  .viewer-placeholder-logo {
+  .web-vitals-chrome-extension .viewer-placeholder-logo {
     margin-right: 16px;
   }
 }
 
 /* app z-indexes */
-.drop_zone {
+.web-vitals-chrome-extension .drop_zone {
   z-index: 3;
 }
 
 /* open-in-viewer option hidden in Viewer */
-.lh-tools__dropdown .lh-tools--viewer {
+.web-vitals-chrome-extension .lh-tools__dropdown .lh-tools--viewer {
   display: none;
 }
 
 /* open-in-gist option visible in Viewer */
-.lh-tools__dropdown .lh-tools--gist {
+.web-vitals-chrome-extension .lh-tools__dropdown .lh-tools--gist {
   display: block !important;
 }
 
-.lh-overlay {
+.web-vitals-chrome-extension .lh-overlay {
   position: fixed;
   z-index: 100000000;
   top: 20px;
@@ -1666,7 +1664,7 @@
   display: inline-block;
 }
 
-.lh-overlay::before {
+.web-vitals-chrome-extension .lh-overlay::before {
   content: "";
   display: block;
   position: absolute;
@@ -1677,45 +1675,45 @@
   opacity: 0.8;
 }
 
-.lh-overlay .metric-name {
+.web-vitals-chrome-extension .lh-overlay .metric-name {
   color: white;
 }
-.lh-overlay .lh-columns {
+.web-vitals-chrome-extension .lh-overlay .lh-columns {
   padding: 0 5px 15px;
 }
-.lh-overlay .lh-column {
+.web-vitals-chrome-extension .lh-overlay .lh-column {
   color: white;
 }
-.lh-overlay .lh-audit-group__title {
+.web-vitals-chrome-extension .lh-overlay .lh-audit-group__title {
     color: white;
     margin: 10px 0 0 10px;
 }
-.lh-overlay .lh-column {
+.web-vitals-chrome-extension .lh-overlay .lh-column {
     margin-right: 2px;
 }
-.lh-overlay .lh-metric__value {
+.web-vitals-chrome-extension .lh-overlay .lh-metric__value {
     margin-right: 6px;
 }
-.lh-overlay .lh-metric__innerwrap {
+.web-vitals-chrome-extension .lh-overlay .lh-metric__innerwrap {
     margin-left: 2px;
 }
-.lh-overlay .lh-metric__subtitle {
+.web-vitals-chrome-extension .lh-overlay .lh-metric__subtitle {
     font-size: var(--report-font-size-small);
     color: var(--color-gray-600);
 }
 
-.lh-warning {
+.web-vitals-chrome-extension .lh-warning {
   display: block;
   background-color: var(--topbar-background-color);
   padding: 4px 6px 6px 6px;
   height: var(--topbar-height);
 }
 
-.lh-overlay .lh-metric-state {
+.web-vitals-chrome-extension .lh-overlay .lh-metric-state {
   color: var(--color-informative);
 }
 
-#web-vitals-close, .lh-overlay-close {
+.web-vitals-chrome-extension #web-vitals-close, .lh-overlay-close {
   all: unset;
   font-family: Roboto, Helvetica, Arial, sans-serif;
   font-weight: bold; 
@@ -1733,38 +1731,38 @@
   margin: 7px 9px 0px 0px;
 }
 
-.lh-footer .lh-generated {
+.web-vitals-chrome-extension .lh-footer .lh-generated {
   text-align: center;
 }
-.lh-env__title {
+.web-vitals-chrome-extension .lh-env__title {
   font-size: var(--env-item-font-size-big);
   line-height: var(--env-item-line-height-big);
   text-align: center;
   padding: var(--score-container-padding);
 }
-.lh-env {
+.web-vitals-chrome-extension .lh-env {
   padding: var(--default-padding) 0;
 }
-.lh-env__items {
+.web-vitals-chrome-extension .lh-env__items {
   padding-left: 16px;
   margin: 0 0 var(--audits-margin-bottom);
   padding: 0;
 }
-.lh-env__items .lh-env__item:nth-child(2n) {
+.web-vitals-chrome-extension .lh-env__items .lh-env__item:nth-child(2n) {
   background-color: var(--env-item-background-color);
 }
-.lh-env__item {
+.web-vitals-chrome-extension .lh-env__item {
   display: flex;
   padding: var(--env-item-padding);
   position: relative;
 }
-span.lh-env__name {
+.web-vitals-chrome-extension span.lh-env__name {
   font-weight: bold;
   min-width: var(--env-name-min-width);
   flex: 0.5;
   padding: 0 8px;
 }
-span.lh-env__description {
+.web-vitals-chrome-extension span.lh-env__description {
   text-align: left;
   flex: 1;
 }

--- a/src/browser_action/viewer.css
+++ b/src/browser_action/viewer.css
@@ -1531,9 +1531,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-:root {
-  --lh-background-color: #304ffe;
-}
 
 .web-vitals-chrome-extension .drop_zone {
   display: flex;

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -92,10 +92,11 @@
     }) => {
       if (enableOverlay === true && overlayClosedForSession == false) {
         // Overlay
-        const overlayElement = document.getElementById('web-vitals-extension');
+        const overlayElement = document.getElementById('web-vitals-extension-overlay');
         if (overlayElement === null) {
           const overlayElement = document.createElement('div');
-          overlayElement.id = 'web-vitals-extension';
+          overlayElement.id = 'web-vitals-extension-overlay';
+          overlayElement.classList.add('web-vitals-chrome-extension');
           overlayElement.innerHTML = buildOverlayTemplate(metrics, tabLoadedInBackground);
           document.body.appendChild(overlayElement);
         } else {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="web-vitals-chrome-extension">
 
 <head>
     <title>Core Web Vitals Options</title>


### PR DESCRIPTION
Fixes #47, #46 

Gmail with the fixes:

![image](https://user-images.githubusercontent.com/110953/81120438-8fd35900-8ee1-11ea-8271-44797dc17528.png)

This should also address a number of cases where injected styles may have otherwise caused issues and should (🤞) resolve Rick's suggestion in #45 

Overlay still rendering after these changes:

![image](https://user-images.githubusercontent.com/110953/81120576-e04ab680-8ee1-11ea-9388-1c33280ec153.png)

Pop-out:

![image](https://user-images.githubusercontent.com/110953/81120593-e6d92e00-8ee1-11ea-9a5c-f7225aae1c14.png)

Options:

![image](https://user-images.githubusercontent.com/110953/81120605-ee98d280-8ee1-11ea-8c10-2b30800045cb.png)






 