### PR TITLE
CPU Usage Improvements

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -170,7 +170,7 @@ function badgeMetric(metric, value, tabid) {
           tabId: currentTab,
         });
         chrome.browserAction.setBadgeText({
-          text: (value).toFixed(2).toString(),
+          text: (value).toFixed(2),
           tabId: currentTab,
         });
         break;
@@ -184,7 +184,7 @@ function badgeMetric(metric, value, tabid) {
           tabId: currentTab,
         });
         chrome.browserAction.setBadgeText({
-          text: value.toFixed(2).toString(),
+          text: value.toFixed(2),
           tabId: currentTab,
         });
         break;

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -199,6 +199,12 @@
  * Fetches Web Vitals metrics via WebVitals.js
  */
   function fetchWebPerfMetrics() {
+    // web-vitals.js doesn't have a way to remove previous listeners, so we'll save whether
+    // we've already installed the listeners before installing them again.
+    // See https://github.com/GoogleChrome/web-vitals/issues/55.
+    if (self._hasInstalledPerfMetrics) return;
+    self._hasInstalledPerfMetrics = true;
+
     webVitals.getCLS((metric) => {
       // As CLS values can fire frequently in the case
       // of animations or highly-dynamic content, we

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -192,7 +192,7 @@
     debouncedCLSBroadcast = _.debounce(broadcastCLS, DEBOUNCE_DELAY, {
       leading: true,
       trailing: true,
-      maxWait: 5000});
+      maxWait: 1000});
   }
   /**
  *

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -240,7 +240,7 @@
           <div class="lh-metric__innerwrap">
             <div>
               <span class="lh-metric__title">
-                Largest Contentful Paint 
+                Largest Contentful Paint${' '}
                   <span class="lh-metric-state">${metrics.lcp.final ? '' : '(might change)'}</span></span>
                   ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
@@ -250,7 +250,7 @@
         <div class="lh-metric lh-metric--${metrics.fid.pass ? 'pass':'fail'}">
           <div class="lh-metric__innerwrap">
             <span class="lh-metric__title">
-              First Input Delay 
+              First Input Delay${' '}
                 <span class="lh-metric-state">${metrics.fid.final ? '' : '(waiting for input)'}</span></span>
             <div class="lh-metric__value">${metrics.fid.final ? `${metrics.fid.value.toFixed(2)}&nbsp;ms` : ''}</div>
           </div>
@@ -258,7 +258,7 @@
         <div class="lh-metric lh-metric--${metrics.cls.pass ? 'pass':'fail'}">
           <div class="lh-metric__innerwrap">
             <span class="lh-metric__title">
-              Cumulative Layout Shift 
+              Cumulative Layout Shift${' '}
                 <span class="lh-metric-state">${metrics.cls.final ? '' : '(might change)'}</span></span>
             <div class="lh-metric__value">${metrics.cls.value.toFixed(3)}&nbsp;</div>
           </div>


### PR DESCRIPTION
fixes #67 or at least it did on my machine :)

Two main problems I found:
1. There was a leak in the Web Vitals listeners installation. Every time a tab is activated it installs another listener (which would kick off the entire flow). This is almost definitely what made me uninstall it on my machine. I probably switch to GMail 1000 times or more during the lifetime of my browser session and so every CLS event then starts triggering 1000 postMessages. Also why the debounce didn't end up doing all that much.
2. Animations aren't cancelled so every metric update kicks on an animation that competes (this manifested as flickering of the badge)