### PR TITLE
fix: remove dead PSI forwarding listener memory leak

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -207,23 +207,6 @@ function badgeMetric(metric, value, tabid) {
 }
 
 /**
- *
- * Broadcast collected WebVitals metrics for usage in the PSI popup
- * @param {Object} badgeMetrics
- */
-function passVitalsToPSI(badgeMetrics) {
-  chrome.tabs.onUpdated.addListener((tabId, {status}, tab) => {
-    if (status == 'complete') {
-      chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-        chrome.runtime.sendMessage({
-          metrics: badgeMetrics,
-        });
-      });
-    }
-  });
-}
-
-/**
  * Wait ms milliseconds
  *
  * @param {Number} ms
@@ -278,10 +261,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.passesAllThresholds !== undefined) {
     // e.g passesAllThresholds === 'GOOD' => green badge
     animateBadges(request, sender.tab.id);
-    // also pass the WebVitals metrics on to PSI for when
-    // the badge icon is clicked and the pop-up opens.
-    passVitalsToPSI(request.metrics);
-    // Store latest metrics locally only
+    // Store latest metrics locally only.
+    // The popup will load the metric values from this storage.
     if (sender.tab.url) {
       const key = hashCode(sender.tab.url);
       chrome.storage.local.set({[key]: request.metrics});


### PR DESCRIPTION
AFAICT this code is not used. The metric values are pulled from storage in the popup and nothing I could find listened for the event that was being issued.

On top of that, this chunk of code adds a listener every time a metric update event is issued :)


**Repro Steps**

1. Open a clean browser profile.
1. Inspect background page and open Memory + Performance Monitor panels.
1. Reset the extension at `chrome://extensions` and  *then* open 5 tabs of `https://melodic-class.glitch.me/cls-forever.html`
1. Hold down Ctrl+Tab for 60 seconds.

**Before**
![image](https://user-images.githubusercontent.com/2301202/85205717-b2c79a00-b2e2-11ea-9d32-e00fd123badb.png)


**After**
![image](https://user-images.githubusercontent.com/2301202/85205756-f02c2780-b2e2-11ea-9b7a-b57c71eb00b6.png)
