### PR TITLE
fix: end animations when the tab is destroyed

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -233,6 +233,16 @@ function wait(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * @param {number} tabId
+ * @return {Promise<boolean>}
+ */
+function doesTabExist(tabId) {
+  return new Promise((resolve) => {
+    chrome.tabs.get(tabId, () => resolve(!chrome.runtime.lastError));
+  });
+}
+
 /** @type {number} */
 let globalAnimationId = 0;
 /** @type {Map<number, number>} */
@@ -269,6 +279,8 @@ async function animateBadges(request, tabId) {
     // Loop the animation if no new information came in while we animated.
     await wait(delay);
     if (animationsByTabId.get(tabId) !== animationId) return;
+    // Stop animating if the tab is gone
+    if (!(await doesTabExist(tabId))) return;
     animateBadges(request, tabId);
   }
 }


### PR DESCRIPTION
kinda fixes #71 (memory usage won't grow when no open tabs, but will still grow while tabs are open until GC'd)

