### PR TITLE
Remove the node_modules version of web-vitals.js

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,8 +26,7 @@
   ],
   "web_accessible_resources": [
     "src/browser_action/viewer.css",
-    "src/browser_action/web-vitals.js",
-    "/node_modules/web-vitals/dist/web-vitals.js"
+    "src/browser_action/web-vitals.js"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
IIUC we should always be using the version of web-vitals.js from browser_action rather than node_modules, so removing the latter from the manifest.