### PR TITLE
Fix "waiting for input" when FID exists

### DIFF
--- a/src/browser_action/popup.js
+++ b/src/browser_action/popup.js
@@ -61,17 +61,17 @@ class Popup {
   initMetrics() {
     this.metrics.lcp = new LCP({
       local: this._metrics.lcp.value,
-      finalized: this._metrics.lcp.final,
+      finalized: this._metrics.lcp.final !== false,
       background: this.background
     });
     this.metrics.fid = new FID({
       local: this._metrics.fid.value,
-      finalized: this._metrics.fid.final,
+      finalized: this._metrics.fid.final !== false,
       background: this.background
     });
     this.metrics.cls = new CLS({
       local: this._metrics.cls.value,
-      finalized: this._metrics.cls.final,
+      finalized: this._metrics.cls.final !== false,
       background: this.background
     });
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web-vitals-extension/issues/93

I think the bug was a side-effect of the upgrade to the latest web-vitals.js. The `final` property seems to be omitted now rather than set to `true` by default.

![image](https://user-images.githubusercontent.com/1120896/124055886-bb24db80-d9f2-11eb-90ff-97dc3b00a16e.png)
