### PR TITLE
Add support for User Timings

### DIFF
--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -17,6 +17,7 @@
   let overlayClosedForSession = false;
   let latestCLS = {};
   let enableLogging = localStorage.getItem('web-vitals-extension-debug')=='TRUE';
+  let enableUserTiming = localStorage.getItem('web-vitals-extension-user-timing')=='TRUE';
 
   // Core Web Vitals thresholds
   const LCP_THRESHOLD = 2500;
@@ -95,8 +96,9 @@
     chrome.storage.sync.get({
       enableOverlay: false,
       debug: false,
+      userTiming: false,
     }, ({
-      enableOverlay, debug,
+      enableOverlay, debug, userTiming,
     }) => {
       if (enableOverlay === true && overlayClosedForSession == false) {
         // Overlay
@@ -139,6 +141,13 @@
         localStorage.removeItem('web-vitals-extension-debug');
         enableLogging = false;
       }
+      if (debug) {
+        localStorage.setItem('web-vitals-extension-user-timing', 'TRUE');
+        enableUserTiming = true;
+      } else {
+        localStorage.removeItem('web-vitals-extension-user-timing');
+        enableUserTiming = false;
+      }
     });
   }
 
@@ -177,6 +186,9 @@
     if (enableLogging) {
       console.log('[Web Vitals]', body.name, body.value.toFixed(2), body);
     }
+    if (enableUserTiming) {
+      addUserTimings(body);
+    }
     badgeMetrics[metricName].value = body.value;
     badgeMetrics.location = getURL();
     badgeMetrics.timestamp = getTimestamp();
@@ -189,6 +201,62 @@
         },
         (response) => drawOverlay(badgeMetrics, response.tabId), // TODO: Once the metrics are final, cache locally.
     );
+  }
+
+  function addUserTimings(metric) {
+    switch (metric.name) {
+      case "LCP": {
+        // LCP has a loadTime/renderTime (startTime), but not a duration.
+        // Could visualize relative to timeOrigin, or from loadTime -> renderTime.
+        // Skip for now.
+      }
+      break;
+      case "CLS": {
+        // CLS has a startTime, but not a duration.
+        // Could visualize the time between rendering tasks (Commit-to-Commit).
+        // Skip for now.
+      }
+      break;
+      case "INP": {
+        if (metric.entries.length > 0) {
+          const inpEntry = metric.entries[0];
+
+          // RenderTime is an estimate, because duration is rounded, and may get rounded keydown
+          // In rare cases it can be less than processingEnd and that breaks performance.measure().
+          // Lets make sure its at least 4ms in those cases so you can just barely see it.
+          const presentationTime = inpEntry.startTime + inpEntry.duration;
+          const adjustedPresentationTime = Math.max(inpEntry.processingEnd + 4, presentationTime);
+
+          performance.measure(`[Web Vitals Extension] INP.duration (${inpEntry.name})`, {
+            start: inpEntry.startTime,
+            end: presentationTime,
+          });
+          performance.measure(`[Web Vitals Extension] INP.inputDelay (${inpEntry.name})`, {
+            start: inpEntry.startTime,
+            end: inpEntry.processingStart,
+          });
+          performance.measure(`[Web Vitals Extension] INP.processingTime (${inpEntry.name})`, {
+            start: inpEntry.processingStart,
+            end: inpEntry.processingEnd,
+          });
+          performance.measure(`[Web Vitals Extension] INP.presentationDelay (${inpEntry.name})`, {
+            start: inpEntry.processingEnd,
+            end: adjustedPresentationTime,
+          });
+        }
+      }
+      break;
+      case "FID": {
+        if (metric.entries.length > 0) {
+          const fidEntry = metric.entries[0]
+          performance.measure(`[Web Vitals Extension] FID (${fidEntry.name})`, {
+            start: fidEntry.startTime,
+            end: fidEntry.processingStart,
+          });
+        }
+
+      }
+    }
   }
 
   /**

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -228,7 +228,7 @@
           const presentationTime = inpEntry.startTime + inpEntry.duration;
           const adjustedPresentationTime = Math.max(inpEntry.processingEnd + 4, presentationTime);
 
-          performance.measure(`[Web Vitals Extension] INP.duration (${inpEntry.name})`, {
+          performance.measure(`[Web Vitals] INP.duration (${inpEntry.name})`, {
             start: inpEntry.startTime,
             end: presentationTime,
           });

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -206,7 +206,7 @@
 
   function addUserTimings(metric) {
     switch (metric.name) {
-      case "LCP": {
+      case "LCP":
         // LCP has a loadTime/renderTime (startTime), but not a duration.
         // Could visualize relative to timeOrigin, or from loadTime -> renderTime.
         // Skip for now.

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -232,7 +232,7 @@
             start: inpEntry.startTime,
             end: presentationTime,
           });
-          performance.measure(`[Web Vitals Extension] INP.inputDelay (${inpEntry.name})`, {
+          performance.measure(`[Web Vitals] INP.inputDelay (${inpEntry.name})`, {
             start: inpEntry.startTime,
             end: inpEntry.processingStart,
           });

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -210,15 +210,13 @@
         // LCP has a loadTime/renderTime (startTime), but not a duration.
         // Could visualize relative to timeOrigin, or from loadTime -> renderTime.
         // Skip for now.
-      }
-      break;
-      case "CLS": {
+        break;
+      case "CLS":
         // CLS has a startTime, but not a duration.
         // Could visualize the time between rendering tasks (Commit-to-Commit).
         // Skip for now.
-      }
-      break;
-      case "INP": {
+        break;
+      case "INP":
         if (metric.entries.length > 0) {
           const inpEntry = metric.entries[0];
 
@@ -236,18 +234,17 @@
             start: inpEntry.startTime,
             end: inpEntry.processingStart,
           });
-          performance.measure(`[Web Vitals Extension] INP.processingTime (${inpEntry.name})`, {
+          performance.measure(`[Web Vitals] INP.processingTime (${inpEntry.name})`, {
             start: inpEntry.processingStart,
             end: inpEntry.processingEnd,
           });
-          performance.measure(`[Web Vitals Extension] INP.presentationDelay (${inpEntry.name})`, {
+          performance.measure(`[Web Vitals] INP.presentationDelay (${inpEntry.name})`, {
             start: inpEntry.processingEnd,
             end: adjustedPresentationTime,
           });
         }
-      }
-      break;
-      case "FID": {
+        break;
+      case "FID":
         if (metric.entries.length > 0) {
           const fidEntry = metric.entries[0]
           performance.measure(`[Web Vitals Extension] FID (${fidEntry.name})`, {
@@ -255,8 +252,6 @@
             end: fidEntry.processingStart,
           });
         }
-
-      }
     }
   }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -23,6 +23,11 @@
                     Console Logging
                 </label>
                 <br/>
+                <label for="userTiming">
+                    <input type="checkbox" id="userTiming">
+                    User Timings (for DevTools Performance Panel recordings).
+                </label>
+                <br/>
                 <label for="preferPhoneField">
                     <input type="checkbox" id="preferPhoneField">
                     Compare local experiences to phone field data

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,5 +1,6 @@
 const optionsOverlayNode = document.getElementById('overlay');
 const optionsConsoleLoggingNode = document.getElementById('consoleLogging');
+const optionsUserTimingNode = document.getElementById('userTiming');
 const optionsPreferPhoneFieldNode = document.getElementById('preferPhoneField');
 const optionsSaveBtn = document.getElementById('save');
 const optionsStatus = document.getElementById('status');
@@ -11,6 +12,7 @@ function saveOptions() {
   chrome.storage.sync.set({
     enableOverlay: optionsOverlayNode.checked,
     debug: optionsConsoleLoggingNode.checked,
+    userTiming: optionsUserTimingNode.checked,
     preferPhoneField: optionsPreferPhoneFieldNode.checked,
   }, () => {
     // Update status to let user know options were saved.
@@ -29,10 +31,12 @@ function restoreOptions() {
   chrome.storage.sync.get({
     enableOverlay: false,
     debug: false,
+    userTiming: false,
     preferPhoneField: false,
-  }, ({enableOverlay, debug, preferPhoneField}) => {
+  }, ({enableOverlay, debug, userTiming, preferPhoneField}) => {
     optionsOverlayNode.checked = enableOverlay;
     optionsConsoleLoggingNode.checked = debug;
+    optionsUserTimingNode.checked = userTiming;
     optionsPreferPhoneFieldNode.checked = preferPhoneField;
   });
 }


### PR DESCRIPTION
Now that #98 has landed, we can consider adding support for User Timings to the extension.

User Timings are helpful when using DevTools performance profile recordings.  DevTools does already have some preliminary support for visualizing events, but there some differences with how Web Vitals, and especially the new INP metric, are reported.

There are different ways to accomplish adding User Timings, including just using DevTools Console -- but by adding it directly to this extension, it is incredibly convenient for a few reasons:

* Gets automatically get added on every page load
* The extension is already injecting web-vitals.js, so you don't need to add your own version
* When you start a DevTools profile recording, you lose access to Console, so you cannot use "Record+Reload" flow and then manually add User Timings...
