### PR TITLE
format timestamp in popup instead of blocking main thread

### DIFF
--- a/src/browser_action/popup.js
+++ b/src/browser_action/popup.js
@@ -26,9 +26,11 @@ class Popup {
     }
 
     const {location, timestamp, ..._metrics} = metrics;
+    // Format as a short timestamp (HH:MM:SS).
+    const formattedTimestamp = new Date(timestamp).toLocaleTimeString('en-US', {hourCycle: 'h23'});
 
     this.location = location;
-    this.timestamp = timestamp;
+    this.timestamp = formattedTimestamp;
     this._metrics = _metrics;
     this.background = background;
     this.options = options;

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -194,15 +194,6 @@
   }
 
   /**
-   * Return a short timestamp (HH:MM:SS) for current time
-   * @return {String}
-   */
-  function getTimestamp() {
-    const date = new Date();
-    return date.toLocaleTimeString('en-US', {hourCycle: 'h23'});
-  }
-
-  /**
      *
      * Broadcasts metrics updates using chrome.runtime(), triggering
      * updates to the badge. Will also update the overlay if this option
@@ -219,7 +210,7 @@
     }
     badgeMetrics[metricName].value = body.value;
     badgeMetrics.location = getURL();
-    badgeMetrics.timestamp = getTimestamp();
+    badgeMetrics.timestamp = new Date().toISOString();
     const passes = scoreBadgeMetrics(badgeMetrics);
     
     // Broadcast metrics updates for badging and logging


### PR DESCRIPTION
fixes #107

Timestamp has to go back through `chrome.runtime.sendMessage()` as a JSON compatible string, so this works as well as any other way.