### PR TITLE
Better CLS logging

### DIFF
--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -17,7 +17,6 @@
   const { onEachInteraction } = await import(chrome.runtime.getURL('src/browser_action/on-each-interaction.js'));
   let overlayClosedForSession = false;
   let latestCLS = {};
-  let latestINP = {};
   let enableLogging = localStorage.getItem('web-vitals-extension-debug')=='TRUE';
   let enableUserTiming = localStorage.getItem('web-vitals-extension-user-timing')=='TRUE';
 
@@ -259,12 +258,12 @@
     }
 
     else if (metric.name == 'CLS' && metric.entries.length) {
-      metric.entries.forEach(entry => {
+      for (const entry of metric.entries) {
         console.log('Layout shift - score: ', Math.round(entry.value * 10000) / 10000);
-        entry.sources.map(source => {
+        for (const source of entry.sources) {
           console.log(source.node);
-        })
-      });
+        }
+      };
     }
 
     else if ((metric.name == 'INP'|| metric.name == 'Interaction') &&
@@ -425,7 +424,6 @@
     webVitals.onLCP(broadcastMetricsUpdates, { reportAllChanges: true });
     webVitals.onFID(broadcastMetricsUpdates, { reportAllChanges: true });
     webVitals.onINP((metric) => {
-      latestINP = metric;
       broadcastMetricsUpdates(metric)
     }, { reportAllChanges: true });
 

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -212,7 +212,7 @@
     badgeMetrics.location = getURL();
     badgeMetrics.timestamp = new Date().toISOString();
     const passes = scoreBadgeMetrics(badgeMetrics);
-    
+
     // Broadcast metrics updates for badging and logging
     chrome.runtime.sendMessage({
       passesAllThresholds: passes,
@@ -256,18 +256,16 @@
         'Time (ms)': Math.round(metric.attribution.elementRenderDelay, 0),
       }]);
     }
-    
+
     else if (metric.name == 'CLS' && metric.entries.length) {
       metric.entries.forEach(entry => {
-        console.log('Layout shift:', {
-          'score': Math.round(entry.value * 10000) / 10000,
-          'elements': entry.sources.map(source => {
-            return source.node;
-          })
-        });
+        console.log('Layout shift - score: ', Math.round(entry.value * 10000) / 10000);
+        entry.sources.map(source => {
+          console.log(source.node);
+        })
       });
     }
-    
+
     else if (metric.name == 'INP' &&
         metric.attribution &&
         metric.attribution.eventEntry) {
@@ -295,7 +293,7 @@
         'Time (ms)': Math.round(adjustedPresentationTime - eventEntry.processingEnd, 0),
       }]);
     }
-    
+
     else if (metric.name == 'FID') {
       const eventEntry = metric.attribution.eventEntry;
       console.log('Interaction target:', eventEntry.target);


### PR DESCRIPTION
With #119 the CLS logging looks like this:

<img width="844" alt="image" src="https://user-images.githubusercontent.com/10931297/235648104-7714f785-5293-42ea-95b1-97b0cfa4f0ba.png">

That is each shift is an object, made up of the nodes that shifted. Organisationally, this makes sense but practically this is less than ideal as it leads to two extra clicks to get to the objects to highlight them in the main screen and also messy logs as the array prototype is shown:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/10931297/235648510-0492cdbb-95ed-4f30-ba41-f79972fc288c.png">

This PR changes it log the elements directly, rather than in an object, so they can quickly be hovered over to see the element affected - exactly as how it works for LCP logging:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/10931297/235648855-4e5adf00-bf51-45fd-bbff-1b7fc1ba89b1.png">

It also removes the prototypes. It is a bigger log by default, and less structured, but I think cleaner.

The grouping is still apparent IMHO, as each shift is separated by a "Layout shift - score: X.XX" line:

<img width="758" alt="image" src="https://user-images.githubusercontent.com/10931297/235649210-93873b53-ed30-4d83-9c65-d8cab03d9596.png">



