### PR TITLE
Option to disable badge animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The badge has a number of states:
 * Passing - green
 * One or more metrics failing - red
 
-If one or more metrics are failing, the badge will animate the values of these metrics.
+If one or more metrics are failing, the badge will animate the values of these metrics (this animation can be turned off in the options screen).
 
 ### Detailed drill-down
 

--- a/service_worker.js
+++ b/service_worker.js
@@ -19,7 +19,15 @@ const CLS_THRESHOLD = 0.1;
 const FCP_THRESHOLD = 1800;
 const TTFB_THRESHOLD = 800;
 
-let optionsNoBadgeAnimation = false;
+// Get the optionsNoBadgeAnimation value
+// Actual default is false but lets set to true
+// initially in get sync storage is slow
+let optionsNoBadgeAnimation = true;
+chrome.storage.sync.get({
+  optionsNoBadgeAnimation: false
+}, ({noBadgeAnimation}) => {
+  optionsNoBadgeAnimation = noBadgeAnimation;
+});
 
 /**
  * Hash the URL and return a numeric hash as a String to be used as the key
@@ -304,7 +312,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Listen for changes to noBadgeAnimation option
 function logStorageChange(changes, area) {
   if (area === 'sync' && 'noBadgeAnimation' in changes) {
-    optionsNoBadgeAnimation = changes['noBadgeAnimation'].newValue;
+    optionsNoBadgeAnimation = changes.noBadgeAnimation.newValue;
   }
 }
 chrome.storage.onChanged.addListener(logStorageChange);

--- a/service_worker.js
+++ b/service_worker.js
@@ -20,8 +20,8 @@ const FCP_THRESHOLD = 1800;
 const TTFB_THRESHOLD = 800;
 
 // Get the optionsNoBadgeAnimation value
-// Actual default is false but lets set to true
-// initially in get sync storage is slow
+// Actual default is false but lets set to true initially in case sync storage
+// is slow so users don't experience any animation initially.
 let optionsNoBadgeAnimation = true;
 chrome.storage.sync.get({
   optionsNoBadgeAnimation: false
@@ -265,10 +265,10 @@ async function animateBadges(request, tabId) {
   if (request.passesAllThresholds === 'POOR') {
 
     // However, if user has turned this off, then leave it off.
-    // Note, we don't call animateBadges again so need a new metric event or a
-    // page refresh to re-enable this but better than checking continually,
-    // when unlikely to change in most cases.
-    if (optionsNoBadgeAnimation) {
+    // Note: if optionsNoBadgeAnimation is flipped, it won't start (or stop)
+    // animating immediately until a status change or page reload to avoid
+    // having to check continually. This is similar to HUD and console.logs
+    // not appearing immediately.
       return;
     }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -32,6 +32,11 @@
                     <input type="checkbox" id="preferPhoneField">
                     Compare local experiences to phone field data
                 </label>
+                <br/>
+                <label for="noBadgeAnimation">
+                    <input type="checkbox" id="noBadgeAnimation">
+                    Only show overall status in badge (no animation of failing metrics)
+                </label>
                 <div id="status"></div>
                 <button id="save">Save</button>
                 </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,5 +1,6 @@
 const optionsOverlayNode = document.getElementById('overlay');
 const optionsConsoleLoggingNode = document.getElementById('consoleLogging');
+const optionsNoBadgeAnimation = document.getElementById('noBadgeAnimation');
 const optionsUserTimingNode = document.getElementById('userTiming');
 const optionsPreferPhoneFieldNode = document.getElementById('preferPhoneField');
 const optionsSaveBtn = document.getElementById('save');
@@ -14,6 +15,7 @@ function saveOptions() {
     debug: optionsConsoleLoggingNode.checked,
     userTiming: optionsUserTimingNode.checked,
     preferPhoneField: optionsPreferPhoneFieldNode.checked,
+    noBadgeAnimation: optionsNoBadgeAnimation.checked,
   }, () => {
     // Update status to let user know options were saved.
     optionsStatus.textContent = 'Options saved.';
@@ -33,11 +35,13 @@ function restoreOptions() {
     debug: false,
     userTiming: false,
     preferPhoneField: false,
-  }, ({enableOverlay, debug, userTiming, preferPhoneField}) => {
+    noBadgeAnimation: false,
+  }, ({enableOverlay, debug, userTiming, preferPhoneField, noBadgeAnimation}) => {
     optionsOverlayNode.checked = enableOverlay;
     optionsConsoleLoggingNode.checked = debug;
     optionsUserTimingNode.checked = userTiming;
     optionsPreferPhoneFieldNode.checked = preferPhoneField;
+    optionsNoBadgeAnimation.checked = noBadgeAnimation;
   });
 }
 document.addEventListener('DOMContentLoaded', restoreOptions);


### PR DESCRIPTION
Fixes #89 

This adds an option to disable the cycling of badge updates between overall status and each failing metric.

Note: The badge will still update on status change.

Open to better option name suggestions:

<img width="521" alt="image" src="https://github.com/GoogleChrome/web-vitals-extension/assets/10931297/4d560562-87a3-4fbb-9b83-4a140c45f0d5">
