### PR TITLE
Hide spurious errors from extension console logs

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -49,6 +49,15 @@ function getWebVitals(tabId) {
   }, (result) => {
     // Catch errors such as "This page cannot be scripted due
     // to an ExtensionsSettings policy."
+    let error = chrome.runtime.lastError;
+    if (error && error.message &&
+        !error.message.startsWith("Cannot access contents of url \"chrome") &&
+        !error.message.startsWith("Cannot access a chrome:// URL") &&
+        !error.message.startsWith("Cannot access a chrome-extension:// URL") &&
+        !error.message.startsWith("Cannot access a chrome-search:// URL")
+    ) {
+      console.error(error.message);
+    }
   });
 }
 


### PR DESCRIPTION
Fixes #118 
Fixes #54 
Fixes #56 

As stated in https://github.com/GoogleChrome/web-vitals-extension/issues/118#issue-1673781285 not totally happy hard coding the messages in here, but according to Oliver in Extensions dev rel, there's no easy option to exclude these other than this.