### PR TITLE
Use extension message port for the communication between content script and extension

### DIFF
--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -48,6 +48,10 @@
   // Set up extension message port with the service worker
   let port = chrome.runtime.connect();
   port.onMessage.addListener((response) => {
+    if (response.tabId === undefined) {
+      return;
+    }
+
     drawOverlay(badgeMetrics, response.tabId);
 
     if (enableLogging) {


### PR DESCRIPTION
It seems `chrome.runtime.sendMessage` from a page that's navigating away makes BFCache worse than using message port. Maybe this helps with the issue mentioned in https://github.com/GoogleChrome/web-vitals-extension/issues/117. I'm opening this PR for more discussion.