### PR TITLE
Bug fix for postMessage change

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -326,7 +326,7 @@ chrome.runtime.onConnect.addListener((port) => {
         const key = hashCode(port.sender.tab.url);
         chrome.storage.local.set({[key]: request.metrics});
       }
-      // send TabId to content script, and pass back the updated metric
+      // send TabId to content script
       port.postMessage({tabId: port.sender.tab.id});
     }
   });

--- a/service_worker.js
+++ b/service_worker.js
@@ -327,7 +327,7 @@ chrome.runtime.onConnect.addListener((port) => {
         chrome.storage.local.set({[key]: request.metrics});
       }
       // send TabId to content script, and pass back the updated metric
-      port.postMessage({tabId: port.sender.tab.id, metric: request.metric});
+      port.postMessage({tabId: port.sender.tab.id});
     }
   });
 });

--- a/service_worker.js
+++ b/service_worker.js
@@ -326,8 +326,8 @@ chrome.runtime.onConnect.addListener((port) => {
         const key = hashCode(port.sender.tab.url);
         chrome.storage.local.set({[key]: request.metrics});
       }
-      // send TabId to content script
-      port.postMessage({tabId: port.sender.tab.id});
+      // send TabId to content script, and pass back the updated metric
+      port.postMessage({tabId: port.sender.tab.id, metric: request.metric});
     }
   });
 });

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -19,6 +19,7 @@
   let latestCLS = {};
   let enableLogging = localStorage.getItem('web-vitals-extension-debug')=='TRUE';
   let enableUserTiming = localStorage.getItem('web-vitals-extension-user-timing')=='TRUE';
+  let tabLoadedInBackground;
 
   // Core Web Vitals thresholds
   const LCP_THRESHOLD = webVitals.LCPThresholds[0];
@@ -135,16 +136,9 @@
      * @param {Object} metrics
      * @param {Number} tabId
      */
-  function drawOverlay(metrics, tabId) {
-    let tabLoadedInBackground = false;
-    const key = tabId.toString();
+  function drawOverlay(metrics) {
 
     localStorage.setItem('web-vitals-extension-metrics', JSON.stringify(metrics));
-
-    // Check if tab was loaded in background
-    chrome.storage.local.get(key, (result) => {
-      tabLoadedInBackground = result[key];
-    });
 
     // Check for preferences set in options
     chrome.storage.sync.get({
@@ -177,7 +171,7 @@
           document.body.appendChild(overlayClose);
         }
 
-        overlayElement.innerHTML = buildOverlayTemplate(metrics, tabLoadedInBackground);
+        overlayElement.innerHTML = buildOverlayTemplate(metrics);
       }
 
       if (debug) {
@@ -220,29 +214,31 @@
       metrics: badgeMetrics,
       metric: metric,
     });
+
+    drawOverlay(badgeMetrics);
+
+    if (enableLogging) {
+      logSummaryInfo(metric);
+    }
   }
 
   // Listed to the message response containing the tab id
-  // to update the overlay and log
-  port.onMessage.addListener((response) => {
-    if (response.tabId === undefined) {
+  // to set the tabLoadedInBackground value. Only need to
+  // set this the first time.
+  port.onMessage.addListener((request) => {
+    if (request.tabId === undefined) {
       return;
     }
-    drawOverlay(badgeMetrics, response.tabId);
 
-    if (response.metric === undefined) {
-      return;
-    }
-    if (enableLogging) {
-      const key = response.tabId.toString();
+    const key = request.tabId.toString();
+    if (tabLoadedInBackground === undefined) {
       chrome.storage.local.get(key, result => {
-        const tabLoadedInBackground = result[key];
-        logSummaryInfo(response.metric, tabLoadedInBackground);
+        tabLoadedInBackground = result[key];
       });
     }
   });
 
-  async function logSummaryInfo(metric, tabLoadedInBackground) {
+  async function logSummaryInfo(metric) {
     const formattedValue = metric.name === 'CLS' ? metric.value.toFixed(2) : `${metric.value.toFixed(0)} ms`;
     console.groupCollapsed(
       `${LOG_PREFIX} ${metric.name} %c${formattedValue} (${metric.rating})`,
@@ -490,10 +486,9 @@
   /**
  * Build a template of metrics
  * @param {Object} metrics The metrics
- * @param {Boolean} tabLoadedInBackground
  * @return {String} a populated template of metrics
  */
-  function buildOverlayTemplate(metrics, tabLoadedInBackground) {
+  function buildOverlayTemplate(metrics) {
     return `
     <div id="lh-overlay-container" class="lh-unset lh-root lh-vars dark" style="display: block;">
     <div class="lh-overlay">

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -209,10 +209,14 @@
     const passes = scoreBadgeMetrics(badgeMetrics);
 
     // Broadcast metrics updates for badging
-    port.postMessage({
-      passesAllThresholds: passes,
-      metrics: badgeMetrics,
-    });
+    try {
+      port.postMessage({
+        passesAllThresholds: passes,
+        metrics: badgeMetrics,
+      });
+    } catch (_) {
+      // Do nothing on error, which can happen on tab switches
+    }
 
     drawOverlay(badgeMetrics);
 

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -208,16 +208,21 @@
     badgeMetrics.timestamp = new Date().toISOString();
     const passes = scoreBadgeMetrics(badgeMetrics);
 
-    // Broadcast metrics updates for badging and logging
+    // Broadcast metrics updates for badging
     port.postMessage({
       passesAllThresholds: passes,
       metrics: badgeMetrics,
-      metric: metric,
     });
+
+    drawOverlay(badgeMetrics);
+
+    if (enableLogging) {
+      logSummaryInfo(metric);
+    }
   }
 
   // Listed to the message response containing the tab id
-  // to update the overlay and log
+  // to set the tabLoadedInBackground.
   port.onMessage.addListener((response) => {
     if (response.tabId === undefined) {
       return;
@@ -229,15 +234,6 @@
       chrome.storage.local.get(key, result => {
         tabLoadedInBackground = result[key];
       });
-    }
-
-    drawOverlay(badgeMetrics);
-
-    if (response.metric === undefined) {
-      return;
-    }
-    if (enableLogging) {
-      logSummaryInfo(response.metric);
     }
   });
 


### PR DESCRIPTION
Bug fix following on from #161 as started noticing some errors when using console logging as the `metric` needed for that is not available in the new listener function.

Annoyingly `postMessage` doesn't get a response, so can no longer get the `tabId` (which we use as a key to see if the tab was started in background) hence why we needed to set this up as a separate listener. We now set a `tabLoadedInBackground` variable - and also only set this once rather than for each update as it shouldn't change.

In theory it can be a little racy as depends on the message coming back, but it always was racy anyway, and will be updated on next metric.
