### PR TITLE
Reestablish message port on bfcache restore

### DIFF
--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -49,13 +49,13 @@
   // Set up extension message port with the service worker
   let port = chrome.runtime.connect();
 
-  // // Re-establish the port connection on bfcache restore
-  // window.addEventListener('pageshow', (event) => {
-  //   if (event.persisted) {
-  //     // The page is restored from BFCache, set up a new connection.
-  //     port = chrome.runtime.connect();
-  //   }
-  // });
+  // Re-establish the port connection on bfcache restore
+  window.addEventListener('pageshow', (event) => {
+    if (event.persisted) {
+      // The page is restored from BFCache, set up a new connection.
+      port = chrome.runtime.connect();
+    }
+  });
 
   function initializeMetrics() {
     let metricsState = localStorage.getItem('web-vitals-extension-metrics');

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -49,6 +49,14 @@
   // Set up extension message port with the service worker
   let port = chrome.runtime.connect();
 
+  // // Re-establish the port connection on bfcache restore
+  // window.addEventListener('pageshow', (event) => {
+  //   if (event.persisted) {
+  //     // The page is restored from BFCache, set up a new connection.
+  //     port = chrome.runtime.connect();
+  //   }
+  // });
+
   function initializeMetrics() {
     let metricsState = localStorage.getItem('web-vitals-extension-metrics');
     if (metricsState) {
@@ -302,7 +310,7 @@
         metric.attribution.eventEntry) {
       const subPartString = `${metric.name} sub-part`;
       const eventEntry = metric.attribution.eventEntry;
-      
+
       let eventTarget = eventEntry.target;
       // Sometimes the eventEntry has no target, so we need to hunt it out manually.
       // As of web-vitals@3.5.2 `attribution.eventTarget` does the same thing,


### PR DESCRIPTION
As per: https://developer.chrome.com/blog/bfcache-extension-messaging-changes we need to add some extra code for bfcache restores for future breaking changes in Chrome.

See also https://github.com/GoogleChrome/web-vitals-extension/pull/161#issuecomment-1961671068

To repeat without this fix:

- Launch Chrome >= 123 with `--enable-features=DisconnectExtensionMessagePortWhenPageEntersBFCache`
- Install the extension
- Pin it to extension bar
- Go to https://www.tunetheweb.com/experiments/softnavsdemo/#1
- Note Green circle badge
- Click "Simulate slow interaction"
- Note badge changes to red triangle
- Reload to reset back to Green Circle
- Go to https://www.example.com/
- Go back to restore from bfcache
- Note badge stays at grey 😔
- Click "Simulate slow interaction"
- Note badge stays at grey 😔

Use this branch, and repeat above test, and note last two 😔 are now 😁

FYI: @lozy219 @oliverdunk