### PR TITLE
Improve formatting and stop hardcoding thresholds

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
     }
   ],
   "background": {
-    "service_worker": "service_worker.js"
+    "service_worker": "service_worker.js",
+    "type": "module"
   },
   "content_security_policy": {
     "extension_pages": "default-src 'self'; connect-src https://chromeuxreport.googleapis.com;"

--- a/service_worker.js
+++ b/service_worker.js
@@ -11,13 +11,15 @@
  limitations under the License.
 */
 
+import {CLSThresholds, FCPThresholds, FIDThresholds, INPThresholds, LCPThresholds, TTFBThresholds} from './src/browser_action/web-vitals.js'
+
 // Core Web Vitals thresholds
-const LCP_THRESHOLD = 2500;
-const FID_THRESHOLD = 100;
-const INP_THRESHOLD = 200;
-const CLS_THRESHOLD = 0.1;
-const FCP_THRESHOLD = 1800;
-const TTFB_THRESHOLD = 800;
+const LCP_THRESHOLD = LCPThresholds[0];
+const FID_THRESHOLD = FIDThresholds[0];
+const INP_THRESHOLD = INPThresholds[0];
+const CLS_THRESHOLD = CLSThresholds[0];
+const FCP_THRESHOLD = FCPThresholds[0];
+const TTFB_THRESHOLD = TTFBThresholds[0];
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Get the optionsNoBadgeAnimation value

--- a/service_worker.js
+++ b/service_worker.js
@@ -11,15 +11,6 @@
  limitations under the License.
 */
 
-import {CLSThresholds, FCPThresholds, FIDThresholds, INPThresholds, LCPThresholds, TTFBThresholds} from './src/browser_action/web-vitals.js'
-
-// Core Web Vitals thresholds
-const LCP_THRESHOLD = LCPThresholds[0];
-const FID_THRESHOLD = FIDThresholds[0];
-const INP_THRESHOLD = INPThresholds[0];
-const CLS_THRESHOLD = CLSThresholds[0];
-const FCP_THRESHOLD = FCPThresholds[0];
-const TTFB_THRESHOLD = TTFBThresholds[0];
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Get the optionsNoBadgeAnimation value
@@ -158,7 +149,7 @@ function badgeOverallPerf(badgeCategory, tabid) {
  * @param {Number} value
  * @param {Number} tabid
  */
-function badgeMetric(metric, value, tabid) {
+function badgeMetric(metric, value, rating, tabid) {
   chrome.tabs.query({
     active: true,
     currentWindow: true,
@@ -168,13 +159,13 @@ function badgeMetric(metric, value, tabid) {
 
     // If URL is overall failing the thresholds, only show
     // a red badge for metrics actually failing (issues/22)
-    if (metric === 'cls' && value <= CLS_THRESHOLD) {
+    if (metric === 'cls' && rating === 'good') {
       return;
     }
-    if (metric === 'lcp' && value <= LCP_THRESHOLD) {
+    if (metric === 'lcp' && rating === 'good') {
       return;
     }
-    if (metric === 'inp' && value <= INP_THRESHOLD) {
+    if (metric === 'inp' && (rating === 'good' || rating === null)) {
       return;
     }
 
@@ -297,15 +288,15 @@ async function animateBadges(request, tabId) {
 
     await wait(delay);
     if (animationsByTabId.get(tabId) !== animationId) return;
-    badgeMetric('lcp', request.metrics.lcp.value, tabId);
+    badgeMetric('lcp', request.metrics.lcp.value, request.metrics.lcp.rating, tabId);
 
     await wait(delay);
     if (animationsByTabId.get(tabId) !== animationId) return;
-    badgeMetric('inp', request.metrics.inp.value, tabId);
+    badgeMetric('inp', request.metrics.inp.value, request.metrics.inp.rating, tabId);
 
     await wait(delay);
     if (animationsByTabId.get(tabId) !== animationId) return;
-    badgeMetric('cls', request.metrics.cls.value, tabId);
+    badgeMetric('cls', request.metrics.cls.value, request.metrics.cls.rating, tabId);
 
     // Loop the animation if no new information came in while we animated.
     await wait(delay);

--- a/service_worker.js
+++ b/service_worker.js
@@ -159,10 +159,10 @@ function badgeMetric(metric, value, rating, tabid) {
 
     // If URL is overall failing the thresholds, only show
     // a red badge for metrics actually failing (issues/22)
-    if (metric === 'cls' && rating === 'good') {
+    if (metric === 'lcp' && rating === 'good') {
       return;
     }
-    if (metric === 'lcp' && rating === 'good') {
+    if (metric === 'cls' && rating === 'good') {
       return;
     }
     if (metric === 'inp' && (rating === 'good' || rating === null)) {

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -2,7 +2,7 @@ import {CLSThresholds, FCPThresholds, FIDThresholds, INPThresholds, LCPThreshold
 
 export class Metric {
 
-  constructor({id, name, local, background, thresholds}) {
+  constructor({id, name, local, background, thresholds, rating}) {
     this.id = id;
     this.abbr = id.toUpperCase();
     this.name = name;
@@ -12,6 +12,7 @@ export class Metric {
     this.digitsOfPrecision = 3;
     // This will be replaced with field data, if available.
     this.distribution = [1/3, 1/3, 1/3];
+    this.rating = rating;
   }
 
   formatValue(value) {
@@ -19,29 +20,12 @@ export class Metric {
   }
 
   getAssessmentIndex() {
-    if (!this.thresholds) {
-      console.warn('Unable to assess', this, '(no thresholds)');
-      return undefined;
-    }
-
-    let index = 1;
-    if (this.local <= this.thresholds.good) {
-      index = 0;
-    } else if (this.local > this.thresholds.poor) {
-      index = 2;
-    }
-
-    return index;
-  }
-
-  getAssessment() {
-    const assessments = ['good', 'needs improvement', 'poor'];
-    return assessments[this.getAssessmentIndex()];
-  }
-
-  getAssessmentClass() {
-    const assessments = ['good', 'needs-improvement', 'poor'];
-    return assessments[this.getAssessmentIndex()];
+    const assessments = {
+      'good': 0,
+      'needs-improvement': 1,
+      'poor': 2
+    };
+    return assessments[this.rating];
   }
 
   getRelativePosition(value) {
@@ -154,7 +138,7 @@ export class Metric {
 
 export class LCP extends Metric {
 
-  constructor({local, background}) {
+  constructor({local, background, rating}) {
     const thresholds = {
       good: LCPThresholds[0],
       poor: LCPThresholds[1]
@@ -162,13 +146,15 @@ export class LCP extends Metric {
 
     // TODO(rviscomi): Consider better defaults.
     local = local || 0;
+    rating = rating || 'good';
 
     super({
       id: 'lcp',
       name: 'Largest Contentful Paint',
       local,
       background,
-      thresholds
+      thresholds,
+      rating
     });
   }
 
@@ -178,10 +164,6 @@ export class LCP extends Metric {
       value,
       unit: 'second'
     });
-  }
-
-  getAssessmentIndex() {
-    return super.getAssessmentIndex();
   }
 
   getInfo() {
@@ -196,7 +178,7 @@ export class LCP extends Metric {
 
 export class FID extends Metric {
 
-  constructor({local, background}) {
+  constructor({local, background, rating}) {
     const thresholds = {
       good: FIDThresholds[0],
       poor: FIDThresholds[1]
@@ -207,7 +189,8 @@ export class FID extends Metric {
       name: 'First Input Delay',
       local,
       background,
-      thresholds
+      thresholds,
+      rating
     });
   }
 
@@ -223,19 +206,11 @@ export class FID extends Metric {
     });
   }
 
-  getAssessmentIndex() {
-    if (this.local === null) {
-      return;
-    }
-
-    return super.getAssessmentIndex();
-  }
-
 }
 
 export class INP extends Metric {
 
-  constructor({local, background}) {
+  constructor({local, background, rating}) {
     const thresholds = {
       good: INPThresholds[0],
       poor: INPThresholds[1]
@@ -246,7 +221,8 @@ export class INP extends Metric {
       name: 'Interaction to Next Paint',
       local,
       background,
-      thresholds
+      thresholds,
+      rating
     });
   }
 
@@ -262,19 +238,11 @@ export class INP extends Metric {
     });
   }
 
-  getAssessmentIndex() {
-    if (this.local === null) {
-      return;
-    }
-
-    return super.getAssessmentIndex();
-  }
-
 }
 
 export class CLS extends Metric {
 
-  constructor({local, background}) {
+  constructor({local, background, rating}) {
     const thresholds = {
       good: CLSThresholds[0],
       poor: CLSThresholds[1]
@@ -282,13 +250,15 @@ export class CLS extends Metric {
 
     // TODO(rviscomi): Consider better defaults.
     local = local || 0;
+    rating = rating || 'good';
 
     super({
       id: 'cls',
       name: 'Cumulative Layout Shift',
       local,
       background,
-      thresholds
+      thresholds,
+      rating
     });
   }
 
@@ -303,7 +273,7 @@ export class CLS extends Metric {
 
 export class FCP extends Metric {
 
-  constructor({local, background}) {
+  constructor({local, background, rating}) {
     const thresholds = {
       good: FCPThresholds[0],
       poor: FCPThresholds[1]
@@ -311,13 +281,15 @@ export class FCP extends Metric {
 
     // TODO(rviscomi): Consider better defaults.
     local = local || 0;
+    rating = rating || 'good';
 
     super({
       id: 'fcp',
       name: 'First Contentful Paint',
       local,
       background,
-      thresholds
+      thresholds,
+      rating
     });
   }
 
@@ -327,10 +299,6 @@ export class FCP extends Metric {
       value,
       unit: 'second'
     });
-  }
-
-  getAssessmentIndex() {
-    return super.getAssessmentIndex();
   }
 
   getInfo() {
@@ -345,7 +313,7 @@ export class FCP extends Metric {
 
 export class TTFB extends Metric {
 
-  constructor({local, background}) {
+  constructor({local, background, rating}) {
     const thresholds = {
       good: TTFBThresholds[0],
       poor: TTFBThresholds[1]
@@ -353,13 +321,15 @@ export class TTFB extends Metric {
 
     // TODO(rviscomi): Consider better defaults.
     local = local || 0;
+    rating = rating || 'good';
 
     super({
       id: 'ttfb',
       name: 'Time to First Byte',
       local,
       background,
-      thresholds
+      thresholds,
+      rating
     });
   }
 
@@ -369,10 +339,6 @@ export class TTFB extends Metric {
       value,
       unit: 'second'
     });
-  }
-
-  getAssessmentIndex() {
-    return super.getAssessmentIndex();
   }
 
 }

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -1,3 +1,5 @@
+import {CLSThresholds, FCPThresholds, FIDThresholds, INPThresholds, LCPThresholds, TTFBThresholds} from './web-vitals.js';
+
 export class Metric {
 
   constructor({id, name, local, background, thresholds}) {
@@ -81,13 +83,13 @@ export class Metric {
     return;
   }
 
-  toLocaleFixed({value, unit}) {
+  toLocaleFixed({value, unit, precision}) {
     return value.toLocaleString(undefined, {
       style: unit && 'unit',
       unit,
-      unitDisplay: 'narrow',
-      minimumFractionDigits: this.digitsOfPrecision,
-      maximumFractionDigits: this.digitsOfPrecision
+      unitDisplay: 'short',
+      minimumFractionDigits: precision ?? this.digitsOfPrecision,
+      maximumFractionDigits: precision ?? this.digitsOfPrecision
     });
   }
 
@@ -154,8 +156,8 @@ export class LCP extends Metric {
 
   constructor({local, background}) {
     const thresholds = {
-      good: 2500,
-      poor: 4000
+      good: LCPThresholds[0],
+      poor: LCPThresholds[1]
     };
 
     // TODO(rviscomi): Consider better defaults.
@@ -196,8 +198,8 @@ export class FID extends Metric {
 
   constructor({local, background}) {
     const thresholds = {
-      good: 100,
-      poor: 300
+      good: FIDThresholds[0],
+      poor: FIDThresholds[1]
     };
 
     super({
@@ -216,7 +218,8 @@ export class FID extends Metric {
 
     return this.toLocaleFixed({
       value,
-      unit: 'millisecond'
+      unit: 'millisecond',
+      precision: 0
     });
   }
 
@@ -234,8 +237,8 @@ export class INP extends Metric {
 
   constructor({local, background}) {
     const thresholds = {
-      good: 200,
-      poor: 500
+      good: INPThresholds[0],
+      poor: INPThresholds[1]
     };
 
     super({
@@ -254,7 +257,8 @@ export class INP extends Metric {
 
     return this.toLocaleFixed({
       value,
-      unit: 'millisecond'
+      unit: 'millisecond',
+      precision: 0
     });
   }
 
@@ -272,8 +276,8 @@ export class CLS extends Metric {
 
   constructor({local, background}) {
     const thresholds = {
-      good: 0.10,
-      poor: 0.25
+      good: CLSThresholds[0],
+      poor: CLSThresholds[1]
     };
 
     // TODO(rviscomi): Consider better defaults.
@@ -289,7 +293,10 @@ export class CLS extends Metric {
   }
 
   formatValue(value) {
-    return this.toLocaleFixed({value});
+    return this.toLocaleFixed({
+      value: value,
+      precision: 2
+    });
   }
 
 }
@@ -298,8 +305,8 @@ export class FCP extends Metric {
 
   constructor({local, background}) {
     const thresholds = {
-      good: 1800,
-      poor: 3000
+      good: FCPThresholds[0],
+      poor: FCPThresholds[1]
     };
 
     // TODO(rviscomi): Consider better defaults.
@@ -340,8 +347,8 @@ export class TTFB extends Metric {
 
   constructor({local, background}) {
     const thresholds = {
-      good: 800,
-      poor: 1800
+      good: TTFBThresholds[0],
+      poor: TTFBThresholds[1]
     };
 
     // TODO(rviscomi): Consider better defaults.

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -25,9 +25,9 @@ export class Metric {
     }
 
     let index = 1;
-    if (this.local < this.thresholds.good) {
+    if (this.local <= this.thresholds.good) {
       index = 0;
-    } else if (this.local >= this.thresholds.poor) {
+    } else if (this.local > this.thresholds.poor) {
       index = 2;
     }
 

--- a/src/browser_action/on-each-interaction.js
+++ b/src/browser_action/on-each-interaction.js
@@ -11,11 +11,14 @@
  limitations under the License.
 */
 
+import {INPThresholds} from './web-vitals.js';
+
+
 /**
  * @param {Function} callback
  */
 export function onEachInteraction(callback) {
-  const valueToRating = (score) => score <= 200 ? 'good' : score <= 500 ? 'needs-improvement' : 'poor';
+  const valueToRating = (score) => score <= INPThresholds[0] ? 'good' : score <= INPThresholds[1] ? 'needs-improvement' : 'poor';
 
   const observer = new PerformanceObserver((list) => {
     const interactions = {};

--- a/src/browser_action/popup.js
+++ b/src/browser_action/popup.js
@@ -62,26 +62,32 @@ class Popup {
   initMetrics() {
     this.metrics.lcp = new LCP({
       local: this._metrics.lcp.value,
+      rating: this._metrics.lcp.rating,
       background: this.background
     });
     this.metrics.cls = new CLS({
       local: this._metrics.cls.value,
+      rating: this._metrics.cls.rating,
       background: this.background
     });
     this.metrics.inp = new INP({
       local: this._metrics.inp.value,
+      rating: this._metrics.inp.rating,
       background: this.background
     });
     this.metrics.fid = new FID({
       local: this._metrics.fid.value,
+      rating: this._metrics.fid.rating,
       background: this.background
     });
     this.metrics.fcp = new FCP({
       local: this._metrics.fcp.value,
+      rating: this._metrics.fcp.rating,
       background: this.background
     });
     this.metrics.ttfb = new TTFB({
       local: this._metrics.ttfb.value,
+      rating: this._metrics.ttfb.rating,
       background: this.background
     });
 
@@ -124,11 +130,11 @@ class Popup {
     const hovercard = document.querySelector(`#${metric.id} .hovercard`);
     const abbr = metric.abbr;
     const local = metric.formatValue(metric.local);
-    const assessment = metric.getAssessment();
+    const assessment = metric.rating;
     let text = `Your local <strong>${abbr}</strong> experience is <strong class="hovercard-local">${local}</strong> and rated <strong class="hovercard-local">${assessment}</strong>.`;
 
     if (fieldData) {
-      const assessmentIndex = metric.getAssessmentIndex();
+      const assessmentIndex = metric.getAssessmentIndex(metric.rating);
       const density = metric.getDensity(assessmentIndex, 0);
       const scope = CrUX.isOriginFallback(fieldData) ? 'origin' : 'page';
       text += ` <strong>${density}</strong> of <span class="nowrap">real-user</span> ${formFactor.toLowerCase()} <strong>${abbr}</strong> experiences on this ${scope} were also rated <strong class="hovercard-local">${assessment}</strong>.`
@@ -150,13 +156,13 @@ class Popup {
     const localValue = fragment.querySelector('.metric-performance-local-value');
     const infoElement = fragment.querySelector('.info');
     const info = metric.getInfo() || '';
-    const assessment = metric.getAssessmentClass();
+    const rating = metric.rating;
 
     metricElement.id = metric.id;
     name.innerText = metric.name;
     local.style.marginLeft = metric.getRelativePosition(metric.local);
     localValue.innerText = metric.formatValue(metric.local);
-    metricElement.classList.toggle(assessment, !!assessment);
+    metricElement.classList.toggle(rating, !!rating);
     infoElement.title = info;
     infoElement.classList.toggle('hidden', info == '');
 

--- a/src/browser_action/viewer.css
+++ b/src/browser_action/viewer.css
@@ -360,7 +360,7 @@
   color: var(--color-gray-500);
 }
 
-.web-vitals-chrome-extension .lh-audit__description, 
+.web-vitals-chrome-extension .lh-audit__description,
 .web-vitals-chrome-extension .lh-audit__stackpack {
   --inner-audit-padding-right: var(--stackpack-padding-horizontal);
   padding-left: var(--audit-description-padding-left);
@@ -437,26 +437,29 @@
   margin: var(--score-icon-margin);
 }
 
+.web-vitals-chrome-extension .lh-audit--good .lh-audit__display-text,
 .web-vitals-chrome-extension .lh-audit--pass .lh-audit__display-text {
   color: var(--color-pass-secondary);
 }
+.web-vitals-chrome-extension .lh-audit--good .lh-audit__score-icon,
 .web-vitals-chrome-extension .lh-audit--pass .lh-audit__score-icon {
   border-radius: 100%;
   background: var(--color-pass);
 }
 
-.web-vitals-chrome-extension .lh-audit--average .lh-audit__display-text {
+.web-vitals-chrome-extension .lh-audit--needs-improvement .lh-audit__display-text {
   color: var(--color-average-secondary);
 }
-.web-vitals-chrome-extension .lh-audit--average .lh-audit__score-icon {
+.web-vitals-chrome-extension .lh-audit--needs-improvement .lh-audit__score-icon {
+  border-radius: 100%;
   background: var(--color-average);
-  width: var(--icon-square-size);
-  height: var(--icon-square-size);
 }
 
+.web-vitals-chrome-extension .lh-audit--poor .lh-audit__display-text,
 .web-vitals-chrome-extension .lh-audit--fail .lh-audit__display-text {
   color: var(--color-fail-secondary);
 }
+.web-vitals-chrome-extension.lh-audit--poor .lh-audit__score-icon,
 .web-vitals-chrome-extension.lh-audit--fail .lh-audit__score-icon,
 .web-vitals-chrome-extension.lh-audit--error .lh-audit__score-icon {
   border-left: calc(var(--score-icon-size) / 2) solid transparent;
@@ -712,12 +715,20 @@
   margin: var(--score-icon-margin);
 }
 
-.web-vitals-chrome-extension .lh-metric--pass .lh-metric__value {
+.web-vitals-chrome-extension .lh-metric--good .lh-metric__value {
   color: var(--color-pass-secondary);
 }
-.web-vitals-chrome-extension .lh-metric--pass .lh-metric__innerwrap::before {
+.web-vitals-chrome-extension .lh-metric--good .lh-metric__innerwrap::before {
   border-radius: 100%;
   background: var(--color-pass);
+}
+
+.web-vitals-chrome-extension .lh-metric--needs-improvement .lh-metric__value {
+  color: var(--color-average-secondary);
+}
+.web-vitals-chrome-extension .lh-metric--needs-improvement .lh-metric__innerwrap::before {
+  border-radius: 100%;
+  background: var(--color-average);
 }
 
 .web-vitals-chrome-extension .lh-metric--average .lh-metric__value {
@@ -729,10 +740,11 @@
   height: var(--icon-square-size);
 }
 
-.web-vitals-chrome-extension .lh-metric--fail .lh-metric__value {
+.web-vitals-chrome-extension .lh-metric--poor .lh-metric__value {
   color: var(--color-fail-secondary);
 }
-.web-vitals-chrome-extension .lh-metric--fail .lh-metric__innerwrap::before,
+
+.web-vitals-chrome-extension .lh-metric--poor .lh-metric__innerwrap::before,
 .web-vitals-chrome-extension .lh-metric--error .lh-metric__innerwrap::before {
   border-left: calc(var(--score-icon-size) / 2) solid transparent;
   border-right: calc(var(--score-icon-size) / 2) solid transparent;
@@ -1717,7 +1729,7 @@
 .web-vitals-chrome-extension #web-vitals-close, .lh-overlay-close {
   all: unset;
   font-family: Roboto, Helvetica, Arial, sans-serif;
-  font-weight: bold; 
+  font-weight: bold;
   font-size: 16px;
   position: fixed;
   z-index: 100000000;
@@ -1728,7 +1740,7 @@
   border-width: initial;
   border-style: initial;
   border-image: initial;
-  display: block; 
+  display: block;
   margin: 7px 9px 0px 0px;
 }
 

--- a/src/browser_action/viewer.css
+++ b/src/browser_action/viewer.css
@@ -718,6 +718,7 @@
 .web-vitals-chrome-extension .lh-metric--good .lh-metric__value {
   color: var(--color-pass-secondary);
 }
+.web-vitals-chrome-extension .lh-metric--waiting .lh-metric__innerwrap::before,
 .web-vitals-chrome-extension .lh-metric--good .lh-metric__innerwrap::before {
   border-radius: 100%;
   background: var(--color-pass);

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -43,6 +43,9 @@
   // Identifiable prefix for console logging
   const LOG_PREFIX = '[Web Vitals Extension]';
 
+  // Default units of precision for HUD
+  const DEFAULT_UNITS_OF_PRECISION = 3;
+
   // Registry for badge metrics
   const badgeMetrics = initializeMetrics();
 
@@ -56,6 +59,16 @@
       port = chrome.runtime.connect();
     }
   });
+
+  function toLocaleFixed({value, unit, precision }) {
+    return value.toLocaleString(undefined, {
+      style: unit && 'unit',
+      unit,
+      unitDisplay: 'short',
+      minimumFractionDigits: precision ?? DEFAULT_UNITS_OF_PRECISION,
+      maximumFractionDigits: precision ?? DEFAULT_UNITS_OF_PRECISION
+    });
+  }
 
   function initializeMetrics() {
     let metricsState = localStorage.getItem('web-vitals-extension-metrics');
@@ -308,7 +321,6 @@
     else if ((metric.name == 'INP'|| metric.name == 'Interaction') &&
         metric.attribution &&
         metric.attribution.eventEntry) {
-      const subPartString = `${metric.name} sub-part`;
       const eventEntry = metric.attribution.eventEntry;
 
       let eventTarget = eventEntry.target;
@@ -329,15 +341,15 @@
         const adjustedPresentationTime = Math.max(entry.processingEnd + 4, entry.startTime + entry.duration);
 
         console.table([{
-          subPartString: 'Input delay',
+          'Interaction sub-part': 'Input delay',
           'Time (ms)': Math.round(entry.processingStart - entry.startTime, 0),
         },
         {
-          subPartString: 'Processing time',
+          'Interaction sub-part': 'Processing time',
           'Time (ms)': Math.round(entry.processingEnd - entry.processingStart, 0),
         },
         {
-          subPartString: 'Presentation delay',
+          'Interaction sub-part': 'Presentation delay',
           'Time (ms)': Math.round(adjustedPresentationTime - entry.processingEnd, 0),
         }]);
       }
@@ -523,13 +535,13 @@
               <span class="lh-metric__title">Largest Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${((metrics.lcp.value || 0)/1000).toFixed(2)}&nbsp;s</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.lcp.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.cls.pass ? 'pass':'fail'}">
           <div class="lh-metric__innerwrap">
             <span class="lh-metric__title">Cumulative Layout Shift</span>
-            <div class="lh-metric__value">${(metrics.cls.value || 0).toFixed(3)}</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: metrics.cls.value || 0, precision: 2})}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.inp.pass ? 'pass':'fail'} lh-metric--${metrics.inp.value === null ? 'waiting' : 'ready'}">
@@ -540,7 +552,7 @@
             </span>
             <div class="lh-metric__value">${
               metrics.inp.value === null ? '' :
-              `${metrics.inp.value.toFixed(2)}&nbsp;ms`
+              `${toLocaleFixed({value: metrics.inp.value, unit: 'millisecond', precision: 0})}`
             }</div>
           </div>
         </div>
@@ -552,7 +564,7 @@
             </span>
             <div class="lh-metric__value">${
               metrics.fid.value === null ? '' :
-              `${metrics.fid.value.toFixed(2)}&nbsp;ms`
+              `${toLocaleFixed({value: metrics.fid.value, unit: 'millisecond', precision: 0})}`
             }</div>
           </div>
         </div>
@@ -562,7 +574,7 @@
               <span class="lh-metric__title">First Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${((metrics.fcp.value || 0)/1000).toFixed(2)}&nbsp;s</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.fcp.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
         <div class="lh-column">
@@ -571,7 +583,7 @@
             <span class="lh-metric__title">
               Time to First Byte
             </span>
-            <div class="lh-metric__value">${((metrics.ttfb.value || 0)/1000).toFixed(2)}&nbsp;s</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.ttfb.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
       </div>

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -116,7 +116,11 @@
     // Note: overallScore is treated as a string rather than
     // a boolean to give us the flexibility of introducing a
     // 'NEEDS IMPROVEMENT' option here in the future.
-    const overallScore = (metrics.lcp.rating === 'good' && metrics.cls.rating === 'good' && (metrics.inp.rating === 'good' || metrics.inp.rating === null) ) ? 'GOOD' : 'POOR';
+    const overallScore = (
+      metrics.lcp.rating === 'good' &&
+      (metrics.cls.rating === 'good' || metrics.cls.rating === null) &&
+      (metrics.inp.rating === 'good' || metrics.inp.rating === null)
+    ) ? 'GOOD' : 'POOR';
     return overallScore;
   }
 
@@ -239,8 +243,9 @@
         formattedValue = toLocaleFixed({value: metric.value, precision: 2});
         break;
       case 'INP':
+      case 'Interaction':
       case 'FID':
-        formattedValue = toLocaleFixed({value: metric.value, unit: 'millisecond', precision: 2});
+        formattedValue = toLocaleFixed({value: metric.value, unit: 'millisecond', precision: 0});
         break;
       default:
         formattedValue = toLocaleFixed({value: metric.value / 1000, unit: 'second', precision: 3});

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -21,19 +21,6 @@
   let enableUserTiming = localStorage.getItem('web-vitals-extension-user-timing')=='TRUE';
   let tabLoadedInBackground;
 
-  // Core Web Vitals thresholds
-  const LCP_GOOD_THRESHOLD = webVitals.LCPThresholds[0];
-  const FID_GOOD_THRESHOLD = webVitals.FIDThresholds[0];
-  const INP_GOOD_THRESHOLD = webVitals.INPThresholds[0];
-  const CLS_GOOD_THRESHOLD = webVitals.CLSThresholds[0];
-  const FCP_GOOD_THRESHOLD = webVitals.FCPThresholds[0];
-  const TTFB_GOOD_THRESHOLD = webVitals.TTFBThresholds[0];
-  const LCP_POOR_THRESHOLD = webVitals.LCPThresholds[1];
-  const FID_POOR_THRESHOLD = webVitals.FIDThresholds[1];
-  const INP_POOR_THRESHOLD = webVitals.INPThresholds[1];
-  const CLS_POOR_THRESHOLD = webVitals.CLSThresholds[1];
-  const FCP_POOR_THRESHOLD = webVitals.FCPThresholds[1];
-  const TTFB_POOR_THRESHOLD = webVitals.TTFBThresholds[1];
   const COLOR_GOOD = '#0CCE6A';
   const COLOR_NEEDS_IMPROVEMENT = '#FFA400';
   const COLOR_POOR = '#FF4E42';
@@ -126,16 +113,10 @@
     * @return {String} overall metrics score
   */
   function scoreBadgeMetrics(metrics) {
-    metrics.lcp.rating = metrics.lcp.value <= LCP_GOOD_THRESHOLD ? 'good' : metrics.lcp.value <= LCP_POOR_THRESHOLD ? 'needs-improvement' : 'poor';
-    metrics.cls.rating = metrics.cls.value <= CLS_GOOD_THRESHOLD ? 'good' : metrics.cls.value <= CLS_POOR_THRESHOLD ? 'needs-improvement' : 'poor';
-    metrics.inp.rating = metrics.inp.value <= INP_GOOD_THRESHOLD ? 'good' : metrics.inp.value <= INP_POOR_THRESHOLD ? 'needs-improvement' : 'poor';
-    metrics.fid.rating = metrics.fid.value <= FID_GOOD_THRESHOLD ? 'good' : metrics.fid.value <= FID_POOR_THRESHOLD ? 'needs-improvement' : 'poor';
-    metrics.fcp.rating = metrics.fcp.value <= FCP_GOOD_THRESHOLD ? 'good' : metrics.fcp.value <= FCP_POOR_THRESHOLD ? 'needs-improvement' : 'poor';
-    metrics.ttfb.rating = metrics.ttfb.value <= TTFB_GOOD_THRESHOLD ? 'good' : metrics.ttfb.value <= TTFB_POOR_THRESHOLD ? 'needs-improvement' : 'poor';
     // Note: overallScore is treated as a string rather than
     // a boolean to give us the flexibility of introducing a
     // 'NEEDS IMPROVEMENT' option here in the future.
-    const overallScore = (metrics.lcp.rating === 'good' && metrics.cls.rating === 'good' && metrics.inp.rating === 'good' ) ? 'GOOD' : 'POOR';
+    const overallScore = (metrics.lcp.rating === 'good' && metrics.cls.rating === 'good' && (metrics.inp.rating === 'good' || metrics.inp.rating === null) ) ? 'GOOD' : 'POOR';
     return overallScore;
   }
 
@@ -214,6 +195,7 @@
       addUserTimings(metric);
     }
     badgeMetrics[metric.name.toLowerCase()].value = metric.value;
+    badgeMetrics[metric.name.toLowerCase()].rating = metric.rating;
     badgeMetrics.timestamp = new Date().toISOString();
     const passes = scoreBadgeMetrics(badgeMetrics);
 


### PR DESCRIPTION
Pulling these out of #177 so that's easier to review

Our presentation of our numbers is wildly inconsistent:

<img width="1276" alt="image" src="https://github.com/GoogleChrome/web-vitals-extension/assets/10931297/991d40ce-568b-41ee-803e-a4593a3711a7">

- 2 decimal places for LCP in HUD and popup
- seconds in HUD and popup but milliseconds in console logging
- space before the units in HUD and console but not in popup
- 3 decimal places for CLS in HUD and popup even though only ever given to 2 decimal places
- 2 decimal places for INP/FID in HUD and popup as if ms precision wasn't enough
- Popup uses user's locale, others do not
- Popup as a metric on threshold (e.g. INP 200ms) fails when others say it's got to be > 200ms (this is why it's bad to have thresholds repeated all over the place!)
- HUD doesn't use amber but rest of them do

This PR cleans that all up:

<img width="1380" alt="image" src="https://github.com/GoogleChrome/web-vitals-extension/assets/10931297/75601d41-06a8-4c70-8d2e-695a2080cf34">

