### PR TITLE
Avoid locale formatting per metric update as a performance improvement

### DIFF
--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -67,10 +67,9 @@ export class Metric {
     return;
   }
 
-  formattedValue({value, unit, precision}) {
+  toLocaleFixed({value, unit, precision}) {
     // Ideally we'd use toLocaleString but that has performance implications
     // (see https://github.com/GoogleChrome/web-vitals-extension/issues/107)
-    // Convert toLocaleString units to short form
     let formattedUnit = '';
     switch (unit) {
       case 'second':
@@ -166,7 +165,7 @@ export class LCP extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.formattedValue({
+    return this.toLocaleFixed({
       value,
       unit: 'second'
     });
@@ -205,7 +204,7 @@ export class FID extends Metric {
       return 'Waiting for input…';
     }
 
-    return this.formattedValue({
+    return this.toLocaleFixed({
       value,
       unit: 'millisecond',
       precision: 0
@@ -237,7 +236,7 @@ export class INP extends Metric {
       return 'Waiting for input…';
     }
 
-    return this.formattedValue({
+    return this.toLocaleFixed({
       value,
       unit: 'millisecond',
       precision: 0
@@ -269,7 +268,7 @@ export class CLS extends Metric {
   }
 
   formatValue(value) {
-    return this.formattedValue({
+    return this.toLocaleFixed({
       value: value,
       precision: 2
     });
@@ -301,7 +300,7 @@ export class FCP extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.formattedValue({
+    return this.toLocaleFixed({
       value,
       unit: 'second'
     });
@@ -341,7 +340,7 @@ export class TTFB extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.formattedValue({
+    return this.toLocaleFixed({
       value,
       unit: 'second'
     });

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -1,5 +1,36 @@
 import {CLSThresholds, FCPThresholds, FIDThresholds, INPThresholds, LCPThresholds, TTFBThresholds} from './web-vitals.js';
 
+const assessments = {
+  'good': 0,
+  'needs-improvement': 1,
+  'poor': 2
+};
+
+const secondsFormatter = new Intl.NumberFormat(undefined, {
+  unit: "second",
+  // style: unit && 'unit',
+  unitDisplay: "short",
+  minimumFractionDigits: 3,
+  maximumFractionDigits: 3
+});
+
+const millisecondsFormatter = new Intl.NumberFormat(undefined, {
+  unit: "millisecond",
+  // style: unit && 'unit',
+  unitDisplay: "short",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+});
+
+const clsFormatter = new Intl.NumberFormat(undefined, {
+  // unit: null,
+  // style: unit && 'unit',
+  unitDisplay: "short",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+});
+
+
 export class Metric {
 
   constructor({id, name, local, background, thresholds, rating}) {
@@ -9,7 +40,6 @@ export class Metric {
     this.local = local;
     this.background = background;
     this.thresholds = thresholds;
-    this.digitsOfPrecision = 3;
     // This will be replaced with field data, if available.
     this.distribution = [1/3, 1/3, 1/3];
     this.rating = rating;
@@ -20,11 +50,6 @@ export class Metric {
   }
 
   getAssessmentIndex() {
-    const assessments = {
-      'good': 0,
-      'needs-improvement': 1,
-      'poor': 2
-    };
     return assessments[this.rating];
   }
 
@@ -65,21 +90,6 @@ export class Metric {
 
   getInfo() {
     return;
-  }
-
-  toLocaleFixed({value, unit, precision}) {
-    // Ideally we'd use toLocaleString but that has performance implications
-    // (see https://github.com/GoogleChrome/web-vitals-extension/issues/107)
-    let formattedUnit = '';
-    switch (unit) {
-      case 'second':
-        formattedUnit = ' s';
-        break;
-      case 'millisecond':
-        formattedUnit = ' ms';
-        break;
-    }
-    return value.toFixed(precision ?? this.digitsOfPrecision) + formattedUnit;
   }
 
   getDensity(i, decimalPlaces=0) {
@@ -165,10 +175,7 @@ export class LCP extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.toLocaleFixed({
-      value,
-      unit: 'second'
-    });
+    return secondsFormatter.format(value);
   }
 
   getInfo() {
@@ -204,11 +211,7 @@ export class FID extends Metric {
       return 'Waiting for input…';
     }
 
-    return this.toLocaleFixed({
-      value,
-      unit: 'millisecond',
-      precision: 0
-    });
+    return millisecondsFormatter.format(value);
   }
 
 }
@@ -236,11 +239,7 @@ export class INP extends Metric {
       return 'Waiting for input…';
     }
 
-    return this.toLocaleFixed({
-      value,
-      unit: 'millisecond',
-      precision: 0
-    });
+    return millisecondsFormatter.format(value);
   }
 
 }
@@ -268,10 +267,7 @@ export class CLS extends Metric {
   }
 
   formatValue(value) {
-    return this.toLocaleFixed({
-      value: value,
-      precision: 2
-    });
+    return clsFormatter.format(value);
   }
 
 }
@@ -300,10 +296,7 @@ export class FCP extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.toLocaleFixed({
-      value,
-      unit: 'second'
-    });
+    return secondsFormatter.format(value);
   }
 
   getInfo() {
@@ -340,10 +333,7 @@ export class TTFB extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.toLocaleFixed({
-      value,
-      unit: 'second'
-    });
+    return secondsFormatter.format(value);
   }
 
 }

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -67,14 +67,20 @@ export class Metric {
     return;
   }
 
-  toLocaleFixed({value, unit, precision}) {
-    return value.toLocaleString(undefined, {
-      style: unit && 'unit',
-      unit,
-      unitDisplay: 'short',
-      minimumFractionDigits: precision ?? this.digitsOfPrecision,
-      maximumFractionDigits: precision ?? this.digitsOfPrecision
-    });
+  formattedValue({value, unit, precision}) {
+    // Ideally we'd use toLocaleString but that has performance implications
+    // (see https://github.com/GoogleChrome/web-vitals-extension/issues/107)
+    // Convert toLocaleString units to short form
+    let formattedUnit = '';
+    switch (unit) {
+      case 'second':
+        formattedUnit = ' s';
+        break;
+      case 'millisecond':
+        formattedUnit = ' ms';
+        break;
+    }
+    return value.toFixed(precision || this.digitsOfPrecision) + formattedUnit;
   }
 
   getDensity(i, decimalPlaces=0) {
@@ -160,7 +166,7 @@ export class LCP extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.toLocaleFixed({
+    return this.formattedValue({
       value,
       unit: 'second'
     });
@@ -199,7 +205,7 @@ export class FID extends Metric {
       return 'Waiting for input…';
     }
 
-    return this.toLocaleFixed({
+    return this.formattedValue({
       value,
       unit: 'millisecond',
       precision: 0
@@ -231,7 +237,7 @@ export class INP extends Metric {
       return 'Waiting for input…';
     }
 
-    return this.toLocaleFixed({
+    return this.formattedValue({
       value,
       unit: 'millisecond',
       precision: 0
@@ -263,7 +269,7 @@ export class CLS extends Metric {
   }
 
   formatValue(value) {
-    return this.toLocaleFixed({
+    return this.formattedValue({
       value: value,
       precision: 2
     });
@@ -295,7 +301,7 @@ export class FCP extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.toLocaleFixed({
+    return this.formattedValue({
       value,
       unit: 'second'
     });
@@ -335,7 +341,7 @@ export class TTFB extends Metric {
 
   formatValue(value) {
     value /= 1000;
-    return this.toLocaleFixed({
+    return this.formattedValue({
       value,
       unit: 'second'
     });

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -79,7 +79,7 @@ export class Metric {
         formattedUnit = ' ms';
         break;
     }
-    return value.toFixed(precision || this.digitsOfPrecision) + formattedUnit;
+    return value.toFixed(precision ?? this.digitsOfPrecision) + formattedUnit;
   }
 
   getDensity(i, decimalPlaces=0) {

--- a/src/browser_action/metric.js
+++ b/src/browser_action/metric.js
@@ -8,7 +8,7 @@ const assessments = {
 
 const secondsFormatter = new Intl.NumberFormat(undefined, {
   unit: "second",
-  // style: unit && 'unit',
+  style: 'unit',
   unitDisplay: "short",
   minimumFractionDigits: 3,
   maximumFractionDigits: 3
@@ -16,16 +16,14 @@ const secondsFormatter = new Intl.NumberFormat(undefined, {
 
 const millisecondsFormatter = new Intl.NumberFormat(undefined, {
   unit: "millisecond",
-  // style: unit && 'unit',
-  unitDisplay: "short",
+  style: 'unit',
+  unitDisplay: 'short',
   minimumFractionDigits: 0,
   maximumFractionDigits: 0
 });
 
 const clsFormatter = new Intl.NumberFormat(undefined, {
-  // unit: null,
-  // style: unit && 'unit',
-  unitDisplay: "short",
+  unitDisplay: 'short',
   minimumFractionDigits: 2,
   maximumFractionDigits: 2
 });

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -53,7 +53,7 @@
     }
   });
 
-  function formatValue({value, unit, precision }) {
+  function toLocaleFixed({value, unit, precision }) {
     // Ideally we'd use toLocaleString but that has performance implications
     // (see https://github.com/GoogleChrome/web-vitals-extension/issues/107)
     let formattedUnit = '';
@@ -245,15 +245,15 @@
     let formattedValue;
     switch(metric.name) {
       case 'CLS':
-        formattedValue = formatValue({value: metric.value, precision: 2});
+        formattedValue = toLocaleFixed({value: metric.value, precision: 2});
         break;
       case 'INP':
       case 'Interaction':
       case 'FID':
-        formattedValue = formatValue({value: metric.value, unit: 'millisecond', precision: 0});
+        formattedValue = toLocaleFixed({value: metric.value, unit: 'millisecond', precision: 0});
         break;
       default:
-        formattedValue = formatValue({value: metric.value / 1000, unit: 'second', precision: 3});
+        formattedValue = toLocaleFixed({value: metric.value / 1000, unit: 'second', precision: 3});
     }
     console.groupCollapsed(
       `${LOG_PREFIX} ${metric.name} %c${formattedValue} (${metric.rating})`,
@@ -526,13 +526,13 @@
               <span class="lh-metric__title">Largest Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${formatValue({value: (metrics.lcp.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.lcp.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.cls.rating}">
           <div class="lh-metric__innerwrap">
             <span class="lh-metric__title">Cumulative Layout Shift</span>
-            <div class="lh-metric__value">${formatValue({value: metrics.cls.value || 0, precision: 2})}</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: metrics.cls.value || 0, precision: 2})}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.inp.rating} lh-metric--${metrics.inp.value === null ? 'waiting' : 'ready'}">
@@ -543,7 +543,7 @@
             </span>
             <div class="lh-metric__value">${
               metrics.inp.value === null ? '' :
-              `${formatValue({value: metrics.inp.value, unit: 'millisecond', precision: 0})}`
+              `${toLocaleFixed({value: metrics.inp.value, unit: 'millisecond', precision: 0})}`
             }</div>
           </div>
         </div>
@@ -555,7 +555,7 @@
             </span>
             <div class="lh-metric__value">${
               metrics.fid.value === null ? '' :
-              `${formatValue({value: metrics.fid.value, unit: 'millisecond', precision: 0})}`
+              `${toLocaleFixed({value: metrics.fid.value, unit: 'millisecond', precision: 0})}`
             }</div>
           </div>
         </div>
@@ -565,7 +565,7 @@
               <span class="lh-metric__title">First Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${formatValue({value: (metrics.fcp.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.fcp.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
         <div class="lh-column">
@@ -574,7 +574,7 @@
             <span class="lh-metric__title">
               Time to First Byte
             </span>
-            <div class="lh-metric__value">${formatValue({value: (metrics.ttfb.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.ttfb.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
       </div>

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -53,20 +53,29 @@
     }
   });
 
-  function toLocaleFixed({value, unit, precision }) {
-    // Ideally we'd use toLocaleString but that has performance implications
-    // (see https://github.com/GoogleChrome/web-vitals-extension/issues/107)
-    let formattedUnit = '';
-    switch (unit) {
-      case 'second':
-        formattedUnit = ' s';
-        break;
-      case 'millisecond':
-        formattedUnit = ' ms';
-        break;
-    }
-    return value.toFixed(precision ?? DEFAULT_UNITS_OF_PRECISION) + formattedUnit;
-  }
+  const secondsFormatter = new Intl.NumberFormat(undefined, {
+    unit: "second",
+    // style: unit && 'unit',
+    unitDisplay: "short",
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3
+  });
+
+  const millisecondsFormatter = new Intl.NumberFormat(undefined, {
+    unit: "millisecond",
+    // style: unit && 'unit',
+    unitDisplay: "short",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+  });
+
+  const clsFormatter = new Intl.NumberFormat(undefined, {
+    // unit: null,
+    // style: unit && 'unit',
+    unitDisplay: "short",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
 
   function initializeMetrics() {
     let metricsState = localStorage.getItem('web-vitals-extension-metrics');
@@ -245,15 +254,15 @@
     let formattedValue;
     switch(metric.name) {
       case 'CLS':
-        formattedValue = toLocaleFixed({value: metric.value, precision: 2});
+        formattedValue = clsFormatter.format(metric.value);
         break;
       case 'INP':
       case 'Interaction':
       case 'FID':
-        formattedValue = toLocaleFixed({value: metric.value, unit: 'millisecond', precision: 0});
+        formattedValue = millisecondsFormatter.format(metric.value);
         break;
       default:
-        formattedValue = toLocaleFixed({value: metric.value / 1000, unit: 'second', precision: 3});
+        formattedValue = secondsFormatter.format(metric.value / 1000);
     }
     console.groupCollapsed(
       `${LOG_PREFIX} ${metric.name} %c${formattedValue} (${metric.rating})`,
@@ -526,13 +535,13 @@
               <span class="lh-metric__title">Largest Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.lcp.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${secondsFormatter.format((metrics.lcp.value || 0)/1000)}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.cls.rating}">
           <div class="lh-metric__innerwrap">
             <span class="lh-metric__title">Cumulative Layout Shift</span>
-            <div class="lh-metric__value">${toLocaleFixed({value: metrics.cls.value || 0, precision: 2})}</div>
+            <div class="lh-metric__value">${clsFormatter.format( metrics.cls.value || 0)}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.inp.rating} lh-metric--${metrics.inp.value === null ? 'waiting' : 'ready'}">
@@ -542,8 +551,7 @@
               <span class="lh-metric-state">${metrics.inp.value === null ? '(waiting for input)' : ''}</span>
             </span>
             <div class="lh-metric__value">${
-              metrics.inp.value === null ? '' :
-              `${toLocaleFixed({value: metrics.inp.value, unit: 'millisecond', precision: 0})}`
+              metrics.inp.value === null ? '' : `${millisecondsFormatter.format(metrics.inp.value)}`
             }</div>
           </div>
         </div>
@@ -554,8 +562,7 @@
               <span class="lh-metric-state">${metrics.fid.value === null ? '(waiting for input)' : ''}</span>
             </span>
             <div class="lh-metric__value">${
-              metrics.fid.value === null ? '' :
-              `${toLocaleFixed({value: metrics.fid.value, unit: 'millisecond', precision: 0})}`
+              metrics.fid.value === null ? '' : `${millisecondsFormatter.format(metrics.fid.value)}`
             }</div>
           </div>
         </div>
@@ -565,7 +572,7 @@
               <span class="lh-metric__title">First Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.fcp.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${secondsFormatter.format((metrics.fcp.value || 0)/1000)}</div>
           </div>
         </div>
         <div class="lh-column">
@@ -574,7 +581,7 @@
             <span class="lh-metric__title">
               Time to First Byte
             </span>
-            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.ttfb.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${secondsFormatter.format((metrics.ttfb.value || 0)/1000)}</div>
           </div>
         </div>
       </div>

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -36,9 +36,6 @@
   // Identifiable prefix for console logging
   const LOG_PREFIX = '[Web Vitals Extension]';
 
-  // Default units of precision for HUD
-  const DEFAULT_UNITS_OF_PRECISION = 3;
-
   // Registry for badge metrics
   const badgeMetrics = initializeMetrics();
 

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -55,7 +55,7 @@
 
   const secondsFormatter = new Intl.NumberFormat(undefined, {
     unit: "second",
-    // style: unit && 'unit',
+    style: 'unit',
     unitDisplay: "short",
     minimumFractionDigits: 3,
     maximumFractionDigits: 3
@@ -63,15 +63,13 @@
 
   const millisecondsFormatter = new Intl.NumberFormat(undefined, {
     unit: "millisecond",
-    // style: unit && 'unit',
+    style: 'unit',
     unitDisplay: "short",
     minimumFractionDigits: 0,
     maximumFractionDigits: 0
   });
 
   const clsFormatter = new Intl.NumberFormat(undefined, {
-    // unit: null,
-    // style: unit && 'unit',
     unitDisplay: "short",
     minimumFractionDigits: 2,
     maximumFractionDigits: 2

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -53,14 +53,19 @@
     }
   });
 
-  function toLocaleFixed({value, unit, precision }) {
-    return value.toLocaleString(undefined, {
-      style: unit && 'unit',
-      unit,
-      unitDisplay: 'short',
-      minimumFractionDigits: precision ?? DEFAULT_UNITS_OF_PRECISION,
-      maximumFractionDigits: precision ?? DEFAULT_UNITS_OF_PRECISION
-    });
+  function formatValue({value, unit, precision }) {
+    // Ideally we'd use toLocaleString but that has performance implications
+    // (see https://github.com/GoogleChrome/web-vitals-extension/issues/107)
+    let formattedUnit = '';
+    switch (unit) {
+      case 'second':
+        formattedUnit = ' s';
+        break;
+      case 'millisecond':
+        formattedUnit = ' ms';
+        break;
+    }
+    return value.toFixed(precision || DEFAULT_UNITS_OF_PRECISION) + formattedUnit;
   }
 
   function initializeMetrics() {
@@ -240,15 +245,15 @@
     let formattedValue;
     switch(metric.name) {
       case 'CLS':
-        formattedValue = toLocaleFixed({value: metric.value, precision: 2});
+        formattedValue = formatValue({value: metric.value, precision: 2});
         break;
       case 'INP':
       case 'Interaction':
       case 'FID':
-        formattedValue = toLocaleFixed({value: metric.value, unit: 'millisecond', precision: 0});
+        formattedValue = formatValue({value: metric.value, unit: 'millisecond', precision: 0});
         break;
       default:
-        formattedValue = toLocaleFixed({value: metric.value / 1000, unit: 'second', precision: 3});
+        formattedValue = formatValue({value: metric.value / 1000, unit: 'second', precision: 3});
     }
     console.groupCollapsed(
       `${LOG_PREFIX} ${metric.name} %c${formattedValue} (${metric.rating})`,
@@ -521,13 +526,13 @@
               <span class="lh-metric__title">Largest Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.lcp.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${formatValue({value: (metrics.lcp.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.cls.rating}">
           <div class="lh-metric__innerwrap">
             <span class="lh-metric__title">Cumulative Layout Shift</span>
-            <div class="lh-metric__value">${toLocaleFixed({value: metrics.cls.value || 0, precision: 2})}</div>
+            <div class="lh-metric__value">${formatValue({value: metrics.cls.value || 0, precision: 2})}</div>
           </div>
         </div>
         <div class="lh-metric lh-metric--${metrics.inp.rating} lh-metric--${metrics.inp.value === null ? 'waiting' : 'ready'}">
@@ -538,7 +543,7 @@
             </span>
             <div class="lh-metric__value">${
               metrics.inp.value === null ? '' :
-              `${toLocaleFixed({value: metrics.inp.value, unit: 'millisecond', precision: 0})}`
+              `${formatValue({value: metrics.inp.value, unit: 'millisecond', precision: 0})}`
             }</div>
           </div>
         </div>
@@ -550,7 +555,7 @@
             </span>
             <div class="lh-metric__value">${
               metrics.fid.value === null ? '' :
-              `${toLocaleFixed({value: metrics.fid.value, unit: 'millisecond', precision: 0})}`
+              `${formatValue({value: metrics.fid.value, unit: 'millisecond', precision: 0})}`
             }</div>
           </div>
         </div>
@@ -560,7 +565,7 @@
               <span class="lh-metric__title">First Contentful Paint</span>
               ${tabLoadedInBackground ? '<span class="lh-metric__subtitle">Value inflated as tab was loaded in background</span>' : ''}
             </div>
-            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.fcp.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${formatValue({value: (metrics.fcp.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
         <div class="lh-column">
@@ -569,7 +574,7 @@
             <span class="lh-metric__title">
               Time to First Byte
             </span>
-            <div class="lh-metric__value">${toLocaleFixed({value: (metrics.ttfb.value || 0)/1000, unit: 'second'})}</div>
+            <div class="lh-metric__value">${formatValue({value: (metrics.ttfb.value || 0)/1000, unit: 'second'})}</div>
           </div>
         </div>
       </div>

--- a/src/browser_action/vitals.js
+++ b/src/browser_action/vitals.js
@@ -65,7 +65,7 @@
         formattedUnit = ' ms';
         break;
     }
-    return value.toFixed(precision || DEFAULT_UNITS_OF_PRECISION) + formattedUnit;
+    return value.toFixed(precision ?? DEFAULT_UNITS_OF_PRECISION) + formattedUnit;
   }
 
   function initializeMetrics() {


### PR DESCRIPTION
Issue raised in https://github.com/GoogleChrome/web-vitals-extension/pull/178#discussion_r1593065236

This initialised the formatters once as the extension is initialised, rather than with each metric update for a god performance improvement, but also allows us to keep the INTL option.